### PR TITLE
adapting them to OpenFlow v1.3

### DIFF
--- a/ruby/trema/trema-ruby-utils.c
+++ b/ruby/trema/trema-ruby-utils.c
@@ -43,7 +43,7 @@ set_length( const buffer *openflow_message, uint16_t length ) {
 
 uint16_t
 get_length( const buffer *openflow_message ) {
-  return ( uint16_t ) ( openflow_message->length - sizeof( struct ofp_vendor_header ) );
+  return ( uint16_t ) ( openflow_message->length - sizeof( struct ofp_vendor ) );
 }
 
 

--- a/ruby/trema/vendor.c
+++ b/ruby/trema/vendor.c
@@ -102,7 +102,7 @@ vendor_init( int argc, VALUE *argv, VALUE self ) {
 
         tmp = rb_hash_aref( options, ID2SYM( rb_intern( "vendor" ) ) );
         if ( tmp != Qnil ) {
-          ( ( struct ofp_vendor_header * ) ( vendor->data ) )->vendor = htonl( ( uint32_t ) NUM2UINT( tmp ) );
+          ( ( struct ofp_vendor * ) ( vendor->data ) )->vendor = htonl( ( uint32_t ) NUM2UINT( tmp ) );
         }
 
         tmp = rb_hash_aref( options, ID2SYM( rb_intern( "data" ) ) );
@@ -111,7 +111,7 @@ vendor_init( int argc, VALUE *argv, VALUE self ) {
           uint16_t length = ( uint16_t ) RARRAY_LEN( tmp );
           append_back_buffer( vendor, length );
           set_length( vendor, length );
-          uint8_t *data = ( uint8_t * ) ( ( char * ) vendor->data + sizeof( struct ofp_vendor_header ) );
+          uint8_t *data = ( uint8_t * ) ( ( char * ) vendor->data + sizeof( struct ofp_vendor ) );
           int i;
           for ( i = 0; i < length; i++ ) {
             data[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( tmp )[ i ] );
@@ -145,7 +145,7 @@ static VALUE
 vendor_vendor( VALUE self ) {
   buffer *vendor_message;
   Data_Get_Struct( self, buffer, vendor_message );
-  uint32_t vendor = ntohl( ( ( struct ofp_vendor_header * ) ( vendor_message->data ) )->vendor );
+  uint32_t vendor = ntohl( ( ( struct ofp_vendor * ) ( vendor_message->data ) )->vendor );
   return UINT2NUM( vendor );
 }
 
@@ -164,7 +164,7 @@ vendor_data( VALUE self ) {
 
   if ( length > 0 ) {
     VALUE data_array = rb_ary_new2( length );
-    uint8_t *data = ( uint8_t * ) ( ( char * ) vendor->data + sizeof( struct ofp_vendor_header ) );
+    uint8_t *data = ( uint8_t * ) ( ( char * ) vendor->data + sizeof( struct ofp_vendor ) );
     int i;
     for ( i = 0; i < length; i++ ) {
       rb_ary_push( data_array, INT2FIX( data[ i ] ) );

--- a/src/lib/openflow.h
+++ b/src/lib/openflow.h
@@ -1899,6 +1899,20 @@ struct ofp_experimenter_header {
 };
 OFP_ASSERT(sizeof(struct ofp_experimenter_header) == 16);
 
+
+// B.6.6 Vendor Extensions
+
+/* Vendor extension */
+struct ofp_vendor {
+  struct ofp_header header; /* Type OFPT_VENDOR. */
+  uint32_t vendor;          /* Vendor ID: 
+                             * - MSB 0: low-order bytes are IEEE OUI.
+                             * - MSB != 0: defined by OpenFlow
+                             *   consortium. */
+  /* Vendor-defined arbitrary additional data. */
+};
+
+
 #endif /* openflow.h */
 
 


### PR DESCRIPTION
Some implementations still use "struct ofp_vendor_header" which is compliant with OpenFlow v1.0. I corrected them to conform OpenFlow v1.3.

And I wrote the definition of "struct ofp_vendor" to "src/lib/openflow.h" based on the specification of OpenFlow v1.3.
