### PR TITLE
correct trema startup problem

### DIFF
--- a/ruby/trema/executables.rb
+++ b/ruby/trema/executables.rb
@@ -56,17 +56,9 @@ class Trema::Executables
   end
 
 
-  path "openvswitch/bin/ovs-ofctl"
-  path "openvswitch/bin/ovs-openflowd"
   path "packetin_filter/packetin_filter"
-  path "phost/cli"
-  path "phost/phost"
   path "switch_manager/switch"
   path "switch_manager/switch_manager"
-  path "tremashark/packet_capture"
-  path "tremashark/stdin_relay"
-  path "tremashark/syslog_relay"
-  path "tremashark/tremashark"
 end
 
 


### PR DESCRIPTION
The following error will occur when trema startup script run.

```
# cd ${TREMA_HOME}
# ./trema run objects/examples/learning_switch/learning_switch
ERROR: Trema is not compiled yet!

Please try the following command:
% ./build.rb
```

Currently, trema-edge cannot use, because Trema::Executables requires following executable files.

```
objects/openvswitch/bin/ovs-ofctl
objects/openvswitch/bin/ovs-openflowd
objects/packetin_filter/packetin_filter
objects/phost/cli
objects/phost/phost
objects/switch_manager/switch
objects/switch_manager/switch_manager
objects/tremashark/packet_capture
objects/tremashark/stdin_relay
objects/tremashark/syslog_relay
objects/tremashark/tremashark
```

Trema-edge seems that some functions are dropped.

They seems like to be OVS, phost and tremashark.

About tremashark, this is mentioned at README that is not implemented.
And I guess that you will not support this function, because you're making a new software switch.
Finally, about phost, that seems useless until the new software switch is available.

This patch enables the startup script of "trema" to use after execution of "build.rb".
