### PR TITLE
update hello_switch stub that cooperates with startup-interface

### DIFF
--- a/Rantfile
+++ b/Rantfile
@@ -53,15 +53,9 @@ import "directedrule"
 desc "Build trema."
 task :default => [
   :libtrema,
-#  :rubylib,
   :switch_manager,
   :switch,
   :packetin_filter,
-#  :tremashark,
-#  :packet_capture,
-#  :syslog_relay,
-#  :stdin_relay,
-#  :vendor,
   :examples
 ]
 
@@ -83,20 +77,16 @@ task :default => [
 #]
 # AFTER t-saito MOD
 task :examples => [
-#  "examples:cbench_switch",
   "examples:dumper",
   "examples:hello_trema",
   "examples:learning_switch",
   "examples:list_switches",
-#  "examples:multi_learning_switch",
   "examples:openflow_switch",
   "examples:openflow_message",
-#  "examples:packet_in",
   "examples:repeater_hub",
   "examples:packetin_filter_config",
   "examples:switch_info",
   "examples:switch_monitor",
-#  "examples:traffic_monitor",
 ]
 
 
@@ -237,7 +227,6 @@ import "sys/tgz"
 
 task :vendor => [
   "vendor:oflops",
-#  "vendor:openflow",
   "vendor:openvswitch",
   "vendor:phost",
 ]
@@ -245,7 +234,6 @@ task :vendor => [
 task :distclean => [
   "vendor:cmockery:distclean",
   "vendor:oflops:distclean",
-#  "vendor:openflow:distclean",
   "vendor:openvswitch:distclean",
   "vendor:phost:distclean",
 ]
@@ -711,11 +699,7 @@ end
 ################################################################################
 
 openflow_messages = [
-#  "echo_reply",
-#  "echo_request",
-#  "features_request",
   "hello",
-#  "set_config",
 ]
 
 openflow_message_source_dir = "src/examples/openflow_message"

--- a/Rantfile
+++ b/Rantfile
@@ -89,7 +89,8 @@ task :examples => [
   "examples:learning_switch",
   "examples:list_switches",
 #  "examples:multi_learning_switch",
-#  "examples:openflow_message",
+  "examples:openflow_switch",
+  "examples:openflow_message",
 #  "examples:packet_in",
   "examples:repeater_hub",
   "examples:packetin_filter_config",
@@ -671,15 +672,50 @@ end
 
 
 ################################################################################
+# Build openflow switches
+################################################################################
+
+openflow_switches = [
+  "hello_switch",
+]
+
+openflow_switch_source_dir = "src/examples/openflow_switch"
+openflow_switch_objects_dir = objects( "examples/openflow_switch" )
+
+gen C::Dependencies, dependency( "openflow_switch" ),
+  :search => [ Trema.include ], :sources => sys[ "#{ openflow_switch_source_dir }/*.c" ]
+
+gen Action do
+  source dependency( "openflow_switch" )
+end
+
+gen Directory, openflow_switch_objects_dir
+
+
+gen DirectedRule, openflow_switch_objects_dir => [ openflow_switch_source_dir ], :o => :c do | t |
+  sys "gcc -I#{ Trema.include } -I#{ Trema.openflow } #{ var :CFLAGS } -c -o #{ t.name } #{ t.source }"
+end
+
+
+openflow_switches.each do | each |
+  target = File.join( openflow_switch_objects_dir, each )
+  task "examples:openflow_switch" => target
+  file target => [ File.join( openflow_switch_objects_dir, "#{ each }.o" ), libtrema ] do | t |
+    sys "gcc -L#{ Trema.lib } -o #{ t.name } #{ t.source } -ltrema -lsqlite3 -ldl -lrt -lpthread"
+  end
+end
+
+
+################################################################################
 # Build openflow messages
 ################################################################################
 
 openflow_messages = [
-  "echo_reply",
-  "echo_request",
-  "features_request",
+#  "echo_reply",
+#  "echo_request",
+#  "features_request",
   "hello",
-  "set_config",
+#  "set_config",
 ]
 
 openflow_message_source_dir = "src/examples/openflow_message"

--- a/features/example.message.hello.feature
+++ b/features/example.message.hello.feature
@@ -9,25 +9,25 @@ Feature: Send hello messages
   Scenario: Hello trema
     When I try trema run "./objects/examples/openflow_message/hello 10" with following configuration (backgrounded):
       """
-      vswitch("hello") { 
+      custom_switch("hello") { 
         datapath_id "0xabc" 
-        stub "hello_switch"
+        path "./objects/examples/openflow_switch/hello_switch"
       }
       """
       And wait until "hello" is up
       And I terminated all trema services
-    Then the log file "testswitch.hello.log" should include "received: OFPT_HELLO" x 11
+    Then the log file "customswitch.hello.log" should include "received: OFPT_HELLO" x 11
 
 
   @wip
   Scenario: Hello trema in Ruby
     When I try trema run "./src/examples/openflow_message/hello.rb 0xabc, 10" with following configuration (backgrounded):
       """
-      vswitch("hello-r") {
+      custom_switch("hello-r") {
         datapath_id "0xabc"
-        stub "hello_switch"
+        path "./objects/examples/openflow_switch/hello_switch"
       }
       """
       And wait until "HelloController" is up
       And I terminated all trema services
-    Then the log file "testswitch.hello-r.log" should include "received: OFPT_HELLO" x 11
+    Then the log file "customswitch.hello-r.log" should include "received: OFPT_HELLO" x 11

--- a/features/example.message.hello.feature
+++ b/features/example.message.hello.feature
@@ -5,21 +5,29 @@ Feature: Send hello messages
   So that I can start transactions with switches
 
 
+  @wip
   Scenario: Hello trema
     When I try trema run "./objects/examples/openflow_message/hello 10" with following configuration (backgrounded):
       """
-      vswitch("hello") { datapath_id "0xabc" }
+      vswitch("hello") { 
+        datapath_id "0xabc" 
+        stub "hello_switch"
+      }
       """
       And wait until "hello" is up
       And I terminated all trema services
-    Then the log file "openflowd.hello.log" should include "received: OFPT_HELLO" x 11
+    Then the log file "testswitch.hello.log" should include "received: OFPT_HELLO" x 11
 
 
+  @wip
   Scenario: Hello trema in Ruby
     When I try trema run "./src/examples/openflow_message/hello.rb 0xabc, 10" with following configuration (backgrounded):
       """
-      vswitch("hello-r") { datapath_id "0xabc" }
+      vswitch("hello-r") {
+        datapath_id "0xabc"
+        stub "hello_switch"
+      }
       """
       And wait until "HelloController" is up
       And I terminated all trema services
-    Then the log file "openflowd.hello-r.log" should include "received: OFPT_HELLO" x 11
+    Then the log file "testswitch.hello-r.log" should include "received: OFPT_HELLO" x 11

--- a/features/example.message.hello.feature
+++ b/features/example.message.hello.feature
@@ -5,7 +5,6 @@ Feature: Send hello messages
   So that I can start transactions with switches
 
 
-  @wip
   Scenario: Hello trema
     When I try trema run "./objects/examples/openflow_message/hello 10" with following configuration (backgrounded):
       """

--- a/ruby/trema/custom-switch.rb
+++ b/ruby/trema/custom-switch.rb
@@ -1,9 +1,5 @@
 #
-# The syntax definition of vswitch { ... } stanza in Trema DSL.
-#
-# Author: Yasuhito Takamiya <yasuhito@gmail.com>
-#
-# Copyright (C) 2008-2012 NEC Corporation
+# Copyright (C) 2012 Hiroyasu OHYAMA
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -20,21 +16,34 @@
 #
 
 
-require "trema/dsl/switch"
+require "trema/hardware-switch"
 
 
 module Trema
-  module DSL
-    class Vswitch < Switch
-      def initialize name = nil
-        super name
-        @ip = "127.0.0.1"
-      end
+  class CustomSwitch < HardwareSwitch
+    include Trema::Daemon
 
 
-      def ip str
-        @ip = str
-      end
+    log_file { |vswitch| "customswitch.#{ vswitch.name }.log" }
+
+    
+    def initialize stanza
+      super stanza
+    end
+
+
+    def command
+      "CHIBACH_TMP=#{ Trema.tmp } #{ path } -i #{ dpid_short } > #{ log_file } &"
+    end
+
+
+    ############################################################################
+    private
+    ############################################################################
+
+
+    def path
+      File.join( Trema.home, @stanza[ :path ] )
     end
   end
 end

--- a/ruby/trema/dsl/custom-switch.rb
+++ b/ruby/trema/dsl/custom-switch.rb
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2008-2012 NEC Corporation
+# The syntax definition of custom_switch { ... } stanza in Trema DSL.
+#
+# Copyright (C) 2012 Hiroyasu OHYAMA
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -16,33 +18,20 @@
 #
 
 
-require "trema/hardware-switch"
+require "trema/dsl/switch"
+
 
 module Trema
-  class TestSwitch < HardwareSwitch
-    include Trema::Daemon
+  module DSL
+    class CustomSwitch < Switch
+      def initialize name = nil
+        super name
+      end
 
 
-    log_file { |vswitch| "testswitch.#{ vswitch.name }.log" }
-
-    
-    def initialize stanza
-      super stanza
-    end
-
-
-    def command
-      "CHIBACH_TMP=#{ Trema.tmp } #{ path } -i #{ dpid_short } > #{ log_file } &"
-    end
-
-
-    ############################################################################
-    private
-    ############################################################################
-
-
-    def path
-      File.join( Trema.objects, "examples/openflow_switch/", @stanza[ :stub ] )
+      def path filepath
+        @path = filepath
+      end
     end
   end
 end

--- a/ruby/trema/dsl/syntax.rb
+++ b/ruby/trema/dsl/syntax.rb
@@ -35,6 +35,7 @@ require "trema/open-vswitch"
 require "trema/packetin-filter"
 require "trema/ruby-switch"
 require "trema/switch-manager"
+require "trema/test-switch"
 
 
 module Trema
@@ -66,7 +67,12 @@ module Trema
       def vswitch name = nil, &block
         stanza = Trema::DSL::Vswitch.new( name )
         stanza.instance_eval( &block )
-        Trema::OpenVswitch.new stanza, @config.port
+
+        if stanza[ :stub ].nil?
+          Trema::OpenVswitch.new stanza, @config.port
+        else
+          Trema::TestSwitch.new stanza
+        end
       end
 
 

--- a/ruby/trema/dsl/syntax.rb
+++ b/ruby/trema/dsl/syntax.rb
@@ -27,6 +27,7 @@ require "trema/dsl/run"
 require "trema/dsl/switch"
 require "trema/dsl/vhost"
 require "trema/dsl/vswitch"
+require "trema/dsl/custom-switch"
 require "trema/hardware-switch"
 require "trema/host"
 require "trema/link"
@@ -35,7 +36,7 @@ require "trema/open-vswitch"
 require "trema/packetin-filter"
 require "trema/ruby-switch"
 require "trema/switch-manager"
-require "trema/test-switch"
+require "trema/custom-switch"
 
 
 module Trema
@@ -67,12 +68,7 @@ module Trema
       def vswitch name = nil, &block
         stanza = Trema::DSL::Vswitch.new( name )
         stanza.instance_eval( &block )
-
-        if stanza[ :stub ].nil?
-          Trema::OpenVswitch.new stanza, @config.port
-        else
-          Trema::TestSwitch.new stanza
-        end
+        Trema::OpenVswitch.new stanza, @config.port
       end
 
 
@@ -80,6 +76,13 @@ module Trema
         stanza = Trema::DSL::Rswitch.new( name )
         stanza.instance_eval( &block )
         Trema::RubySwitch.new( stanza )
+      end
+
+
+      def custom_switch name = nil, &block
+        stanza = Trema::DSL::CustomSwitch.new( name )
+        stanza.instance_eval( &block )
+        Trema::CustomSwitch.new stanza
       end
 
 

--- a/ruby/trema/test-switch.rb
+++ b/ruby/trema/test-switch.rb
@@ -1,8 +1,4 @@
 #
-# The syntax definition of vswitch { ... } stanza in Trema DSL.
-#
-# Author: Yasuhito Takamiya <yasuhito@gmail.com>
-#
 # Copyright (C) 2008-2012 NEC Corporation
 #
 # This program is free software; you can redistribute it and/or modify
@@ -20,26 +16,33 @@
 #
 
 
-require "trema/dsl/switch"
-
+require "trema/hardware-switch"
 
 module Trema
-  module DSL
-    class Vswitch < Switch
-      def initialize name = nil
-        super name
-        @ip = "127.0.0.1"
-      end
+  class TestSwitch < HardwareSwitch
+    include Trema::Daemon
 
 
-      def ip str
-        @ip = str
-      end
+    log_file { |vswitch| "testswitch.#{ vswitch.name }.log" }
+
+    
+    def initialize stanza
+      super stanza
+    end
 
 
-      def stub name
-        @stub = name
-      end
+    def command
+      "CHIBACH_TMP=#{ Trema.tmp } #{ path } -i #{ dpid_short } > #{ log_file } &"
+    end
+
+
+    ############################################################################
+    private
+    ############################################################################
+
+
+    def path
+      File.join( Trema.objects, "examples/openflow_switch/", @stanza[ :stub ] )
     end
   end
 end

--- a/src/examples/openflow_switch/hello_switch.c
+++ b/src/examples/openflow_switch/hello_switch.c
@@ -1,7 +1,7 @@
 /*
  * A simple switch that has minimum function to test hello message.
  *
- * Copyright (C) 2008-2012 NEC Corporation
+ * Copyright (C) 2012 Hiroyasu OHYAMA
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2, as


### PR DESCRIPTION
前回指摘されたポイントを修正したものです.

・修正(1) : Trema の設定ファイルの vswitch() でスタブが起動するようにしました

・修正(2) : スタブの場所を変更しました
- src/examples/openflow_switch に src/examples/openflow_message/ と対応が取れるようにしました

・修正(3) : その他コーディングスタイルの修正
- 関数の間隔, 冒頭の Author の記述の排除など
