### PR TITLE
fix write_pid called after daemonize call

### DIFF
--- a/src/switch/switch/switch-init.c
+++ b/src/switch/switch/switch-init.c
@@ -113,6 +113,13 @@ init_parse_args( int argc, char **argv ) {
   init_log( name, switch_log, log_output_type );
   xfree( switch_log );
 
+  ignore_sigpipe();
+#ifdef NOT_TESTED
+  if ( args->run_as_daemon == true ) {
+    daemonize( get_switch_home() );
+  }
+#endif
+
   char *switch_pid_dir = get_switch_pid_dir();
   write_pid( switch_pid_dir, name );
   char cmd[ PATH_MAX ];
@@ -123,13 +130,6 @@ init_parse_args( int argc, char **argv ) {
   snprintf( cmd, PATH_MAX, "chmod 0666 %s/%s.pid", switch_pid_dir, name );
   system( cmd );
   xfree( switch_pid_dir );
-
-  ignore_sigpipe();
-#ifdef NOT_TESTED
-  if ( args->run_as_daemon == true ) {
-    daemonize( get_switch_home() );
-  }
-#endif
 
   return args;
 }


### PR DESCRIPTION
To control daemonized process, we must call write_pid
after the daemonize() call.

Signed-off-by: Hiroaki KAWAI kawai@stratosphere.co.jp
