### PR TITLE
Returning pointers to stack allocated variables has undefined behavior

### DIFF
--- a/ruby/trema/action-common.c
+++ b/ruby/trema/action-common.c
@@ -41,7 +41,7 @@ dl_addr_to_a( VALUE dl_addr, uint8_t *ret_dl_addr ) {
 
 uint8_t *
 mac_addr_to_cstr( VALUE mac_addr ) {
-  uint8_t dl_addr[ OFP_ETH_ALEN ];
+  static __thread uint8_t dl_addr[ OFP_ETH_ALEN ];
   return dl_addr_to_a( mac_addr, dl_addr );
 }
 


### PR DESCRIPTION
The 'mac_addr_to_cstr' function causes mac addresses to zero out due to compiler optimization since pointers to stack allocated memory is not valid outside the scope of the function.

Testing is limited to running trema due to issues with compiling the unit tests.
