### PR TITLE
Unpacking multipart port desc fails due to variable name hiding iterator

### DIFF
--- a/ruby/trema/messages/multipart-reply-handler.c
+++ b/ruby/trema/messages/multipart-reply-handler.c
@@ -435,7 +435,7 @@ unpack_port_desc_multipart_reply( VALUE r_attributes, void *data, size_t length 
     VALUE messages_port = rb_funcall( rb_eval_string( "Messages::Port" ), rb_intern( "new" ), 1, r_port_attrs );
     rb_ary_push( r_ports_ary, messages_port );
     length -= sizeof( struct ofp_port );
-    messages_port++;
+    port++;
   }
   HASH_SET( r_attributes, "ports", r_ports_ary );
 }

--- a/ruby/trema/messages/multipart-reply-handler.c
+++ b/ruby/trema/messages/multipart-reply-handler.c
@@ -432,10 +432,10 @@ unpack_port_desc_multipart_reply( VALUE r_attributes, void *data, size_t length 
   VALUE r_port_attrs = rb_hash_new();
   while ( length >= sizeof( struct ofp_port ) ) {
     unpack_port( port, r_port_attrs );
-    VALUE port = rb_funcall( rb_eval_string( "Messages::Port" ), rb_intern( "new" ), 1, r_port_attrs );
-    rb_ary_push( r_ports_ary, port );
+    VALUE messages_port = rb_funcall( rb_eval_string( "Messages::Port" ), rb_intern( "new" ), 1, r_port_attrs );
+    rb_ary_push( r_ports_ary, messages_port );
     length -= sizeof( struct ofp_port );
-    port++;
+    messages_port++;
   }
   HASH_SET( r_attributes, "ports", r_ports_ary );
 }


### PR DESCRIPTION
Renamed the new Trema::Port variable to ensure the right pointer gets iterated.
