### PR TITLE
fix memory leak in calloc_packet_info

### DIFF
--- a/ruby/trema/conversion-util.c
+++ b/ruby/trema/conversion-util.c
@@ -132,7 +132,7 @@ ofp_match_to_r_match( const struct ofp_match *match ) {
 { \
   VALUE r_value = rb_iv_get( r_match, at_value ); \
   if ( !NIL_P( r_value ) ) { \
-    uint32_t mask = 0; \
+    uint32_t mask = UINT32_MAX; \
     VALUE r_mask = rb_iv_get( r_match, at_value "_mask" ); \
     if ( !NIL_P( r_mask ) ) { \
       mask = NUM2UINT( r_mask ); \
@@ -145,7 +145,7 @@ ofp_match_to_r_match( const struct ofp_match *match ) {
 { \
   VALUE r_value = rb_iv_get( r_match, at_value ); \
   if ( !NIL_P( r_value ) ) { \
-    uint64_t mask = 0; \
+    uint64_t mask = UINT64_MAX; \
     VALUE r_mask = rb_iv_get( r_match, at_value "_mask" ); \
     if ( !NIL_P( r_mask ) ) { \
       mask = ( uint64_t ) NUM2ULL( r_mask ); \
@@ -167,7 +167,7 @@ ofp_match_to_r_match( const struct ofp_match *match ) {
 { \
   VALUE r_value = rb_iv_get( r_match, at_value ); \
   if ( !NIL_P( r_value ) ) { \
-    uint8_t dl_mask[ OFP_ETH_ALEN ] = { 0, 0, 0, 0, 0, 0 }; \
+    uint8_t dl_mask[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }; \
     VALUE r_mask = rb_iv_get( r_match, at_value "_mask" ); \
     if ( !NIL_P( r_mask ) ) { \
       dl_addr_to_a( r_mask, dl_mask ); \
@@ -189,7 +189,7 @@ ofp_match_to_r_match( const struct ofp_match *match ) {
 { \
   VALUE r_value = rb_iv_get( r_match, at_value ); \
   if ( !NIL_P( r_value ) ) { \
-    uint32_t ipv4_mask = 0; \
+    uint32_t ipv4_mask = UINT32_MAX; \
     VALUE r_mask = rb_iv_get( r_match, at_value "_mask" ); \
     if ( !NIL_P( r_mask ) ) { \
       ipv4_mask = nw_addr_to_i( r_mask ); \
@@ -211,7 +211,8 @@ ofp_match_to_r_match( const struct ofp_match *match ) {
 { \
   VALUE r_value = rb_iv_get( r_match, at_value ); \
   if ( !NIL_P( r_value ) ) { \
-    struct in6_addr ipv6_mask = in6addr_any; \
+    struct in6_addr ipv6_mask; \
+    memset( ipv6_mask.s6_addr, 0xff, sizeof( ipv6_mask.s6_addr ) ); \
     VALUE r_mask = rb_iv_get( r_match, at_value "_mask" ); \
     if ( !NIL_P( r_mask ) ) { \
       ipv6_addr_to_in6_addr( r_mask, &ipv6_mask ); \

--- a/ruby/trema/flexible-action.c
+++ b/ruby/trema/flexible-action.c
@@ -76,7 +76,7 @@ static VALUE
 pack_metadata( VALUE self, VALUE actions, VALUE options ) {
   VALUE r_metadata = HASH_REF( options, metadata );
   if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_metadata( oxm_match_ptr( actions ), rb_num2ull( r_metadata ), 0 );
+    append_oxm_match_metadata( oxm_match_ptr( actions ), rb_num2ull( r_metadata ), UINT64_MAX );
   }
 
   return self;
@@ -92,7 +92,7 @@ pack_eth_dst( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_eth_dst( openflow_actions_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    uint8_t eth_dst_mask[ OFP_ETH_ALEN ] = { 0 };
+    uint8_t eth_dst_mask[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
     append_oxm_match_eth_dst( oxm_match_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ), eth_dst_mask );
   }
   xfree( dl_addr );
@@ -110,7 +110,7 @@ pack_eth_src( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_eth_src( openflow_actions_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    uint8_t eth_src_mask[ OFP_ETH_ALEN ] = { 0 };
+    uint8_t eth_src_mask[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
     append_oxm_match_eth_src( oxm_match_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ), eth_src_mask );
   }
   xfree( dl_addr );
@@ -140,7 +140,7 @@ pack_vlan_vid( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_vlan_vid( openflow_actions_ptr( actions ), ( const uint16_t ) NUM2UINT( r_vlan_vid ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_vlan_vid( oxm_match_ptr( actions ), ( const uint16_t ) NUM2UINT( r_vlan_vid ), 0 );
+    append_oxm_match_vlan_vid( oxm_match_ptr( actions ), ( const uint16_t ) NUM2UINT( r_vlan_vid ), UINT16_MAX );
   }
 
   return self;
@@ -210,7 +210,7 @@ pack_ipv4_src_addr( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_ipv4_src( openflow_actions_ptr( actions ), ip_addr_to_i( r_ip_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_ipv4_src( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), 0 ); 
+    append_oxm_match_ipv4_src( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), UINT32_MAX ); 
   }
 
   return self;
@@ -224,7 +224,7 @@ pack_ipv4_dst_addr( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_ipv4_dst( openflow_actions_ptr( actions ), ip_addr_to_i( r_ip_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_ipv4_dst( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), 0 );
+    append_oxm_match_ipv4_dst( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), UINT32_MAX );
   }
 
   return self;
@@ -364,7 +364,7 @@ pack_arp_spa( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_arp_spa( openflow_actions_ptr( actions ), ip_addr_to_i( r_ip_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_arp_spa( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), 0 );
+    append_oxm_match_arp_spa( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), UINT32_MAX );
   }
 
   return self;
@@ -378,7 +378,7 @@ pack_arp_tpa( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_arp_tpa( openflow_actions_ptr( actions ), ip_addr_to_i( r_ip_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_arp_tpa( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), 0 );
+    append_oxm_match_arp_tpa( oxm_match_ptr( actions ), ip_addr_to_i( r_ip_addr ), UINT32_MAX );
   }
 
   return self;
@@ -394,7 +394,7 @@ pack_arp_sha( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_arp_sha( openflow_actions_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    uint8_t mask[ OFP_ETH_ALEN ] = { 0 };
+    uint8_t mask[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
     append_oxm_match_arp_sha( oxm_match_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ), mask );
   }
   xfree( dl_addr );
@@ -412,7 +412,7 @@ pack_arp_tha( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_arp_tha( openflow_actions_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    uint8_t mask[ OFP_ETH_ALEN ] = { 0 };
+    uint8_t mask[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
     append_oxm_match_arp_tha( oxm_match_ptr( actions ), dl_addr_to_a( r_mac_address, dl_addr ), mask );
   }
   xfree( dl_addr );
@@ -431,7 +431,7 @@ pack_ipv6_src_addr( VALUE self, VALUE actions, VALUE options ) {
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
     struct in6_addr in6_mask;
-    memset( &in6_mask, 0, sizeof( struct in6_addr ) );
+    memset( &in6_mask, 0xff, sizeof( struct in6_addr ) );
     append_oxm_match_ipv6_src( oxm_match_ptr( actions ), ipv6_addr_to_in6_addr( r_ip_addr, in6_addr ), in6_mask );
   }
   xfree( in6_addr );
@@ -450,7 +450,7 @@ pack_ipv6_dst_addr( VALUE self, VALUE actions, VALUE options ) {
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
     struct in6_addr in6_mask;
-    memset( &in6_mask, 0, sizeof( struct in6_addr ) );
+    memset( &in6_mask, 0xff, sizeof( struct in6_addr ) );
     append_oxm_match_ipv6_dst( oxm_match_ptr( actions ), ipv6_addr_to_in6_addr( r_ip_addr, in6_addr ), in6_mask );
   }
   xfree( in6_addr );
@@ -466,7 +466,7 @@ pack_ipv6_flow_label( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_ipv6_flabel( openflow_actions_ptr( actions ), NUM2UINT( r_ipv6_flow_label ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_ipv6_flabel( oxm_match_ptr( actions ), NUM2UINT( r_ipv6_flow_label ), 0 );
+    append_oxm_match_ipv6_flabel( oxm_match_ptr( actions ), NUM2UINT( r_ipv6_flow_label ), UINT32_MAX );
   }
 
   return self;
@@ -602,7 +602,7 @@ pack_pbb_isid( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_pbb_isid( openflow_actions_ptr( actions ), ( const uint32_t ) NUM2UINT( r_pbb_isid ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_pbb_isid( oxm_match_ptr( actions ), NUM2UINT( r_pbb_isid ), 0 );
+    append_oxm_match_pbb_isid( oxm_match_ptr( actions ), NUM2UINT( r_pbb_isid ), UINT32_MAX );
   }
 
   return self;
@@ -616,7 +616,7 @@ pack_tunnel_id( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_tunnel_id( openflow_actions_ptr( actions ), ( const uint64_t ) rb_num2ull( r_tunnel_id ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_tunnel_id( oxm_match_ptr( actions ), ( uint64_t ) rb_num2ull( r_tunnel_id ), 0 );
+    append_oxm_match_tunnel_id( oxm_match_ptr( actions ), ( uint64_t ) rb_num2ull( r_tunnel_id ), UINT64_MAX );
   }
 
   return self;
@@ -630,7 +630,7 @@ pack_ipv6_exthdr( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_ipv6_exthdr( openflow_actions_ptr( actions ), ( const uint16_t ) NUM2UINT( r_ipv6_exthdr ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_ipv6_exthdr( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_ipv6_exthdr ), 0 );
+    append_oxm_match_ipv6_exthdr( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_ipv6_exthdr ), UINT16_MAX );
   }
 
   return self;

--- a/src/lib/openflow_message.c
+++ b/src/lib/openflow_message.c
@@ -8062,8 +8062,8 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
   struct in6_addr tmp_ipv6_mask;
   struct in6_addr no_ipv6_mask;
 
-  memset( no_mac_mask, 0, sizeof( no_mac_mask ) );
-  memset( &no_ipv6_mask, 0, sizeof( no_ipv6_mask ) );
+  memset( no_mac_mask, 0xff, sizeof( no_mac_mask ) );
+  memset( &no_ipv6_mask, 0xff, sizeof( no_ipv6_mask ) );
 
   if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_IN_PORT ) ) ) {
     append_oxm_match_in_port( match, in_port );
@@ -8099,7 +8099,7 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
     else {
       vlan_vid = OFPVID_NONE;
     }
-    append_oxm_match_vlan_vid( match, vlan_vid, ( uint16_t ) ( no_mask ? 0 : mask->mask_vlan_vid ) );
+    append_oxm_match_vlan_vid( match, vlan_vid, ( uint16_t ) ( no_mask ? UINT16_MAX : mask->mask_vlan_vid ) );
   }
   if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_VLAN_PCP ) ) ) {
     if ( packet_type_eth_vtag( packet ) ) {
@@ -8129,10 +8129,10 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
       append_oxm_match_ip_proto( match, ip_proto );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_IPV4_SRC ) ) ) {
-      append_oxm_match_ipv4_src( match, ( ( packet_info * ) packet->user_data )->ipv4_saddr, ( uint32_t ) ( no_mask ? 0 : mask->mask_ipv4_src ) );
+      append_oxm_match_ipv4_src( match, ( ( packet_info * ) packet->user_data )->ipv4_saddr, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_ipv4_src ) );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_IPV4_DST ) ) ) {
-      append_oxm_match_ipv4_dst( match, ( ( packet_info * ) packet->user_data )->ipv4_daddr, ( uint32_t ) ( no_mask ? 0 : mask->mask_ipv4_dst ) );
+      append_oxm_match_ipv4_dst( match, ( ( packet_info * ) packet->user_data )->ipv4_daddr, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_ipv4_dst ) );
     }
   }
   else if ( eth_type == ETH_ETHTYPE_IPV6 ) {
@@ -8163,10 +8163,10 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
       append_oxm_match_ipv6_dst( match, ( ( packet_info * ) packet->user_data )->ipv6_daddr, tmp_ipv6_mask );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_IPV6_FLABEL ) ) ) {
-      append_oxm_match_ipv6_flabel( match, ( ( packet_info * ) packet->user_data )->ipv6_flowlabel, ( uint32_t ) ( no_mask ? 0 : mask->mask_flabel ) );
+      append_oxm_match_ipv6_flabel( match, ( ( packet_info * ) packet->user_data )->ipv6_flowlabel, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_flabel ) );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_IPV6_EXTHDR ) ) ) {
-      append_oxm_match_ipv6_exthdr( match, ( ( packet_info * ) packet->user_data )->ipv6_exthdr, ( uint16_t ) ( no_mask ? 0 : mask->mask_ipv6_exthdr ) );
+      append_oxm_match_ipv6_exthdr( match, ( ( packet_info * ) packet->user_data )->ipv6_exthdr, ( uint16_t ) ( no_mask ? UINT32_MAX : mask->mask_ipv6_exthdr ) );
     }
   }
   else if ( eth_type == ETH_ETHTYPE_ARP ) {
@@ -8174,10 +8174,10 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
       append_oxm_match_arp_op( match, ( ( packet_info * ) packet->user_data )->arp_ar_op );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_SPA ) ) ) {
-      append_oxm_match_arp_spa( match, ( ( packet_info * ) packet->user_data )->arp_spa, ( uint32_t ) ( no_mask ? 0 : mask->mask_arp_spa ) );
+      append_oxm_match_arp_spa( match, ( ( packet_info * ) packet->user_data )->arp_spa, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_arp_spa ) );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_TPA ) ) ) {
-      append_oxm_match_arp_tpa( match, ( ( packet_info * ) packet->user_data )->arp_tpa, ( uint32_t ) ( no_mask ? 0 : mask->mask_arp_tpa ) );
+      append_oxm_match_arp_tpa( match, ( ( packet_info * ) packet->user_data )->arp_tpa, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_arp_tpa ) );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_SHA ) ) ) {
       if ( no_mask ) {

--- a/src/lib/oxm_match.c
+++ b/src/lib/oxm_match.c
@@ -287,7 +287,7 @@ bool
 append_oxm_match_metadata( oxm_matches *matches, uint64_t metadata, uint64_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT64_MAX ) {
     return append_oxm_match_64( matches, OXM_OF_METADATA, metadata );
   }
 
@@ -299,8 +299,8 @@ bool
 append_oxm_match_eth_dst( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] ) {
   assert( matches != NULL );
 
-  uint8_t zero[ OFP_ETH_ALEN ] = { 0, 0, 0, 0, 0, 0 };
-  if ( memcmp( mask, zero, OFP_ETH_ALEN ) == 0 ) {
+  uint8_t all_one[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  if ( memcmp( mask, all_one, OFP_ETH_ALEN ) == 0 ) {
     return append_oxm_match_eth_addr( matches, OXM_OF_ETH_DST, addr );
   }
 
@@ -312,8 +312,8 @@ bool
 append_oxm_match_eth_src( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] ) {
   assert( matches != NULL );
 
-  uint8_t zero[ OFP_ETH_ALEN ] = { 0, 0, 0, 0, 0, 0 };
-  if ( memcmp( mask, zero, OFP_ETH_ALEN ) == 0 ) {
+  uint8_t all_one[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  if ( memcmp( mask, all_one, OFP_ETH_ALEN ) == 0 ) {
     return append_oxm_match_eth_addr( matches, OXM_OF_ETH_SRC, addr );
   }
 
@@ -333,7 +333,7 @@ bool
 append_oxm_match_vlan_vid( oxm_matches *matches, uint16_t value, uint16_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT16_MAX ) {
     return append_oxm_match_16( matches, OXM_OF_VLAN_VID, value );
   }
 
@@ -377,7 +377,7 @@ bool
 append_oxm_match_ipv4_src( oxm_matches *matches, uint32_t addr, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_IPV4_SRC, addr );
   }
 
@@ -389,7 +389,7 @@ bool
 append_oxm_match_ipv4_dst( oxm_matches *matches, uint32_t addr, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_IPV4_DST, addr );
   }
 
@@ -473,7 +473,7 @@ bool
 append_oxm_match_arp_spa( oxm_matches *matches, uint32_t addr, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_ARP_SPA, addr );
   }
 
@@ -485,7 +485,7 @@ bool
 append_oxm_match_arp_tpa( oxm_matches *matches, uint32_t addr, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_ARP_TPA, addr );
   }
 
@@ -497,8 +497,8 @@ bool
 append_oxm_match_arp_sha( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] ) {
   assert( matches != NULL );
 
-  uint8_t zero[ OFP_ETH_ALEN ] = { 0, 0, 0, 0, 0, 0 };
-  if ( memcmp( mask, zero, OFP_ETH_ALEN ) == 0 ) {
+  uint8_t all_one[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  if ( memcmp( mask, all_one, OFP_ETH_ALEN ) == 0 ) {
     return append_oxm_match_eth_addr( matches, OXM_OF_ARP_SHA, addr );
   }
 
@@ -510,8 +510,8 @@ bool
 append_oxm_match_arp_tha( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] ) {
   assert( matches != NULL );
 
-  uint8_t zero[ OFP_ETH_ALEN ] = { 0, 0, 0, 0, 0, 0 };
-  if ( memcmp( mask, zero, OFP_ETH_ALEN ) == 0 ) {
+  uint8_t all_one[ OFP_ETH_ALEN ] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+  if ( memcmp( mask, all_one, OFP_ETH_ALEN ) == 0 ) {
     return append_oxm_match_eth_addr( matches, OXM_OF_ARP_THA, addr );
   }
 
@@ -523,7 +523,9 @@ bool
 append_oxm_match_ipv6_src( oxm_matches *matches, struct in6_addr addr, struct in6_addr mask ) {
   assert( matches != NULL );
 
-  if ( IN6_IS_ADDR_UNSPECIFIED( &mask ) ) {
+  struct in6_addr all_one;
+  memset( all_one.s6_addr, 0xff, sizeof( all_one.s6_addr ) );
+  if ( memcmp( mask.s6_addr, all_one.s6_addr, sizeof( mask.s6_addr ) ) == 0 ) {
     return append_oxm_match_ipv6_addr( matches, OXM_OF_IPV6_SRC, addr, mask );
   }
 
@@ -535,7 +537,9 @@ bool
 append_oxm_match_ipv6_dst( oxm_matches *matches, struct in6_addr addr, struct in6_addr mask ) {
   assert( matches != NULL );
 
-  if ( IN6_IS_ADDR_UNSPECIFIED( &mask ) ) {
+  struct in6_addr all_one;
+  memset( all_one.s6_addr, 0xff, sizeof( all_one.s6_addr ) );
+  if ( memcmp( mask.s6_addr, all_one.s6_addr, sizeof( mask.s6_addr ) ) == 0 ) {
     return append_oxm_match_ipv6_addr( matches, OXM_OF_IPV6_DST, addr, mask );
   }
 
@@ -547,7 +551,7 @@ bool
 append_oxm_match_ipv6_flabel( oxm_matches *matches, uint32_t value, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_IPV6_FLABEL, value );
   }
 
@@ -624,7 +628,7 @@ bool
 append_oxm_match_pbb_isid( oxm_matches *matches, uint32_t value, uint32_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT32_MAX ) {
     return append_oxm_match_32( matches, OXM_OF_PBB_ISID, value );
   }
 
@@ -636,7 +640,7 @@ bool
 append_oxm_match_tunnel_id( oxm_matches *matches, uint64_t id, uint64_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT64_MAX ) {
     return append_oxm_match_64( matches, OXM_OF_TUNNEL_ID, id );
   }
 
@@ -648,7 +652,7 @@ bool
 append_oxm_match_ipv6_exthdr( oxm_matches *matches, uint16_t value, uint16_t mask ) {
   assert( matches != NULL );
 
-  if ( mask == 0 ) {
+  if ( mask == UINT16_MAX ) {
     return append_oxm_match_16( matches, OXM_OF_IPV6_EXTHDR, value );
   }
 
@@ -823,7 +827,7 @@ compare_field( void *x, void *y, void *xm, void *ym, size_t len, bool strict ) {
   // mask all F set( exact match )
   xm_val = ym_val = 0xff;
 
-  for ( int i = 0; i < (int) len; i++ ) {
+  for ( int i = 0; i < ( int ) len; i++ ) {
     x_val = *x_p++;
     y_val = *y_p++;
 
@@ -840,7 +844,8 @@ compare_field( void *x, void *y, void *xm, void *ym, size_t len, bool strict ) {
       if ( xm_val != ym_val ) {
         return false;
       }
-    } else {
+    }
+    else {
       if ( ( ~xm_val | ~ym_val ) != ~xm_val ) {
         return false;
       }

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -37,6 +37,12 @@ void
 calloc_packet_info( buffer *buf ) {
   die_if_NULL( buf );
 
+  if ( buf->user_data != NULL && buf->user_data_free_function != NULL ) {
+    ( *buf->user_data_free_function )( buf );
+    assert( buf->user_data == NULL );
+    assert( buf->user_data_free_function == NULL );
+  }
+
   void *user_data = xcalloc( 1, sizeof( packet_info ) );
   assert( user_data != NULL );
 

--- a/src/switch/datapath/action_executor.c
+++ b/src/switch/datapath/action_executor.c
@@ -1226,6 +1226,10 @@ execute_action_dec_mpls_ttl( buffer *frame, action *dec_mpls_ttl ) {
       match->in_phy_port.value = info->eth_in_phy_port;
       match->in_phy_port.valid = true;
     }
+    if ( info->metadata != 0 ) {
+      match->metadata.value = info->metadata;
+      match->metadata.valid = true;
+    }
     notify_packet_in( OFPR_INVALID_TTL, dec_mpls_ttl->entry->table_id, dec_mpls_ttl->entry->cookie, match, frame, MISS_SEND_LEN );
     delete_match( match );
   }
@@ -1268,6 +1272,10 @@ execute_action_dec_nw_ttl( buffer *frame, action *dec_nw_ttl ) {
     if ( info->eth_in_phy_port != match->in_port.value ) {
       match->in_phy_port.value = info->eth_in_phy_port;
       match->in_phy_port.valid = true;
+    }
+    if ( info->metadata != 0 ) {
+      match->metadata.value = info->metadata;
+      match->metadata.valid = true;
     }
     notify_packet_in( OFPR_INVALID_TTL, dec_nw_ttl->entry->table_id, dec_nw_ttl->entry->cookie, match, frame, MISS_SEND_LEN );
     delete_match( match );
@@ -1730,6 +1738,10 @@ execute_action_output( buffer *frame, action *output ) {
       if ( info->eth_in_phy_port != match->in_port.value ) {
         match->in_phy_port.value = info->eth_in_phy_port;
         match->in_phy_port.valid = true;
+      }
+      if ( info->metadata != 0 ) {
+        match->metadata.value = info->metadata;
+        match->metadata.valid = true;
       }
       if ( output->entry->table_miss ) {
         notify_packet_in( OFPR_NO_MATCH, output->entry->table_id, output->entry->cookie, match, frame, MISS_SEND_LEN );

--- a/src/switch/datapath/flow_entry.c
+++ b/src/switch/datapath/flow_entry.c
@@ -115,7 +115,6 @@ dump_flow_entry( const flow_entry *entry, void dump_function( const char *format
   if ( entry->match != NULL ) {
     dump_match( entry->match, dump_function );
   }
-
   else {
     ( *dump_function )( "NULL" );
   }

--- a/src/switch/datapath/instruction.c
+++ b/src/switch/datapath/instruction.c
@@ -377,25 +377,25 @@ duplicate_instruction_set( const instruction_set *instructions ) {
 
   instruction_set *duplicated = create_instruction_set();
 
-  if ( duplicated->goto_table != NULL ) {
+  if ( instructions->goto_table != NULL ) {
     duplicated->goto_table = duplicate_instruction( instructions->goto_table );
   }
-  if ( duplicated->write_metadata != NULL ) {
+  if ( instructions->write_metadata != NULL ) {
     duplicated->write_metadata = duplicate_instruction( instructions->write_metadata );
   }
-  if ( duplicated->write_actions != NULL ) {
+  if ( instructions->write_actions != NULL ) {
     duplicated->write_actions = duplicate_instruction( instructions->write_actions );
   }
-  if ( duplicated->apply_actions != NULL ) {
+  if ( instructions->apply_actions != NULL ) {
     duplicated->apply_actions = duplicate_instruction( instructions->apply_actions );
   }
-  if ( duplicated->clear_actions != NULL ) {
+  if ( instructions->clear_actions != NULL ) {
     duplicated->clear_actions = duplicate_instruction( instructions->clear_actions );
   }
-  if ( duplicated->meter != NULL ) {
+  if ( instructions->meter != NULL ) {
     duplicated->meter = duplicate_instruction( instructions->meter );
   }
-  if ( duplicated->experimenter != NULL ) {
+  if ( instructions->experimenter != NULL ) {
     duplicated->experimenter = duplicate_instruction( instructions->experimenter );
   }
 

--- a/src/switch/datapath/port_manager.c
+++ b/src/switch/datapath/port_manager.c
@@ -316,7 +316,7 @@ append_switch_port_to_list( switch_port *port, void *user_data ) {
 static list_element *
 get_switch_ports_to_output( const uint32_t port_no, const uint32_t in_port ) {
   assert( port_no > 0 );
-  assert( in_port <= OFPP_MAX );
+  assert( in_port <= OFPP_MAX || in_port == OFPP_CONTROLLER );
 
   switch_port_list ports;
   create_list( &ports.list );
@@ -396,7 +396,11 @@ send_frame_from_switch_port( const uint32_t port_no, buffer *frame ) {
   }
 
   OFDPE ret = OFDPE_SUCCESS;
-  if ( port_no != OFPP_TABLE ) {
+  if ( port_no == OFPP_IN_PORT && in_port == OFPP_CONTROLLER ) {
+    warn( "Packet-out with in_port = OFPP_CONTROLLER is not supported." );
+    ret = OFDPE_FAILED;
+  }
+  else if ( port_no != OFPP_TABLE ) {
     list_element *ports = get_switch_ports_to_output( port_no, in_port );
     for ( list_element *e = ports; e != NULL;  e = e->next ) {
       assert( e->data != NULL );


### PR DESCRIPTION
memory leak would happen when multiple parse_packet was called on the same buffer.
