### PR TITLE
fix segfault when fetching a packet by buffer_id

### DIFF
--- a/src/lib/buffer.c
+++ b/src/lib/buffer.c
@@ -301,6 +301,13 @@ void
 reset_buffer( buffer *buf ) {
   assert( buf != NULL );
 
+  if ( buf->user_data != NULL && buf->user_data_free_function != NULL ) {
+    ( *buf->user_data_free_function )( buf );
+    assert( buf->user_data == NULL );
+    assert( buf->user_data_free_function == NULL );
+  }
+  buf->user_data = NULL;
+
   pthread_mutex_lock( ( ( private_buffer * ) buf )->mutex );
 
   private_buffer *pbuf = ( private_buffer * ) buf;

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -65,16 +65,16 @@ copy_packet_info( buffer *dst, const buffer *src ) {
   memcpy( dst->user_data, src->user_data, sizeof( packet_info ) );
 
   packet_info *info = ( packet_info* ) dst->user_data;
-  ssize_t offset = (dst->data - src->data);
+  ssize_t offset = ( ( char * ) dst->data - ( char * ) src->data);
 
-  if(info->l2_header      != NULL) ( char * ) info->l2_header      += offset;
-  if(info->l2_payload     != NULL) ( char * ) info->l2_payload     += offset;
-  if(info->l3_header      != NULL) ( char * ) info->l3_header      += offset;
-  if(info->l3_payload     != NULL) ( char * ) info->l3_payload     += offset;
-  if(info->l4_header      != NULL) ( char * ) info->l4_header      += offset;
-  if(info->l4_payload     != NULL) ( char * ) info->l4_payload     += offset;
-  if(info->l2_vlan_header != NULL) ( char * ) info->l2_vlan_header += offset;
-  if(info->l2_mpls_header != NULL) ( char * ) info->l2_mpls_header += offset;
+  if(info->l2_header      != NULL) info->l2_header      = ( char * ) info->l2_header      + offset;
+  if(info->l2_payload     != NULL) info->l2_payload     = ( char * ) info->l2_payload     + offset;
+  if(info->l3_header      != NULL) info->l3_header      = ( char * ) info->l3_header      + offset;
+  if(info->l3_payload     != NULL) info->l3_payload     = ( char * ) info->l3_payload     + offset;
+  if(info->l4_header      != NULL) info->l4_header      = ( char * ) info->l4_header      + offset;
+  if(info->l4_payload     != NULL) info->l4_payload     = ( char * ) info->l4_payload     + offset;
+  if(info->l2_vlan_header != NULL) info->l2_vlan_header = ( char * ) info->l2_vlan_header + offset;
+  if(info->l2_mpls_header != NULL) info->l2_mpls_header = ( char * ) info->l2_mpls_header + offset;
 }
 
 

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -61,14 +61,14 @@ copy_packet_info( buffer *dst, const buffer *src ) {
   packet_info *info = ( packet_info* ) dst->user_data;
   ssize_t offset = (dst->data - src->data);
 
-  if(info->l2_header      != NULL) info->l2_header      += offset;
-  if(info->l2_payload     != NULL) info->l2_payload     += offset;
-  if(info->l3_header      != NULL) info->l3_header      += offset;
-  if(info->l3_payload     != NULL) info->l3_payload     += offset;
-  if(info->l4_header      != NULL) info->l4_header      += offset;
-  if(info->l4_payload     != NULL) info->l4_payload     += offset;
-  if(info->l2_vlan_header != NULL) info->l2_vlan_header += offset;
-  if(info->l2_mpls_header != NULL) info->l2_mpls_header += offset;
+  if(info->l2_header      != NULL) ( char * ) info->l2_header      += offset;
+  if(info->l2_payload     != NULL) ( char * ) info->l2_payload     += offset;
+  if(info->l3_header      != NULL) ( char * ) info->l3_header      += offset;
+  if(info->l3_payload     != NULL) ( char * ) info->l3_payload     += offset;
+  if(info->l4_header      != NULL) ( char * ) info->l4_header      += offset;
+  if(info->l4_payload     != NULL) ( char * ) info->l4_payload     += offset;
+  if(info->l2_vlan_header != NULL) ( char * ) info->l2_vlan_header += offset;
+  if(info->l2_mpls_header != NULL) ( char * ) info->l2_mpls_header += offset;
 }
 
 

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -53,6 +53,31 @@ calloc_packet_info( buffer *buf ) {
 }
 
 
+void
+copy_packet_info( buffer *dst, const buffer *src ) {
+  die_if_NULL( src );
+  die_if_NULL( dst );
+  
+  if ( src->user_data == NULL ) {
+    return;
+  }
+  calloc_packet_info( dst );
+  memcpy( dst->user_data, src->user_data, sizeof( packet_info ) );
+
+  packet_info *info = ( packet_info* ) dst->user_data;
+  ssize_t offset = (dst->data - src->data);
+
+  if(info->l2_header      != NULL) info->l2_header      += offset;
+  if(info->l2_payload     != NULL) info->l2_payload     += offset;
+  if(info->l3_header      != NULL) info->l3_header      += offset;
+  if(info->l3_payload     != NULL) info->l3_payload     += offset;
+  if(info->l4_header      != NULL) info->l4_header      += offset;
+  if(info->l4_payload     != NULL) info->l4_payload     += offset;
+  if(info->l2_vlan_header != NULL) info->l2_vlan_header += offset;
+  if(info->l2_mpls_header != NULL) info->l2_mpls_header += offset;
+}
+
+
 packet_info
 get_packet_info( const buffer *frame ) {
   die_if_NULL( frame );

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -47,6 +47,31 @@ calloc_packet_info( buffer *buf ) {
 }
 
 
+void
+copy_packet_info( buffer *dst, const buffer *src ) {
+  die_if_NULL( src );
+  die_if_NULL( dst );
+  
+  if ( src->user_data == NULL ) {
+    return;
+  }
+  calloc_packet_info( dst );
+  memcpy( dst->user_data, src->user_data, sizeof( packet_info ) );
+
+  packet_info *info = ( packet_info* ) dst->user_data;
+  ssize_t offset = (dst->data - src->data);
+
+  if(info->l2_header      != NULL) info->l2_header      += offset;
+  if(info->l2_payload     != NULL) info->l2_payload     += offset;
+  if(info->l3_header      != NULL) info->l3_header      += offset;
+  if(info->l3_payload     != NULL) info->l3_payload     += offset;
+  if(info->l4_header      != NULL) info->l4_header      += offset;
+  if(info->l4_payload     != NULL) info->l4_payload     += offset;
+  if(info->l2_vlan_header != NULL) info->l2_vlan_header += offset;
+  if(info->l2_mpls_header != NULL) info->l2_mpls_header += offset;
+}
+
+
 packet_info
 get_packet_info( const buffer *frame ) {
   die_if_NULL( frame );

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -67,14 +67,14 @@ copy_packet_info( buffer *dst, const buffer *src ) {
   packet_info *info = ( packet_info* ) dst->user_data;
   ssize_t offset = (dst->data - src->data);
 
-  if(info->l2_header      != NULL) info->l2_header      += offset;
-  if(info->l2_payload     != NULL) info->l2_payload     += offset;
-  if(info->l3_header      != NULL) info->l3_header      += offset;
-  if(info->l3_payload     != NULL) info->l3_payload     += offset;
-  if(info->l4_header      != NULL) info->l4_header      += offset;
-  if(info->l4_payload     != NULL) info->l4_payload     += offset;
-  if(info->l2_vlan_header != NULL) info->l2_vlan_header += offset;
-  if(info->l2_mpls_header != NULL) info->l2_mpls_header += offset;
+  if(info->l2_header      != NULL) ( char * ) info->l2_header      += offset;
+  if(info->l2_payload     != NULL) ( char * ) info->l2_payload     += offset;
+  if(info->l3_header      != NULL) ( char * ) info->l3_header      += offset;
+  if(info->l3_payload     != NULL) ( char * ) info->l3_payload     += offset;
+  if(info->l4_header      != NULL) ( char * ) info->l4_header      += offset;
+  if(info->l4_payload     != NULL) ( char * ) info->l4_payload     += offset;
+  if(info->l2_vlan_header != NULL) ( char * ) info->l2_vlan_header += offset;
+  if(info->l2_mpls_header != NULL) ( char * ) info->l2_mpls_header += offset;
 }
 
 

--- a/src/lib/packet_info.h
+++ b/src/lib/packet_info.h
@@ -237,6 +237,7 @@ bool parse_packet( buffer *buf );
 
 void calloc_packet_info( buffer *frame );
 void free_packet_info( buffer *frame );
+void copy_packet_info( buffer *dst, const buffer *src );
 packet_info get_packet_info( const buffer *frame );
 
 bool packet_type_eth_dix( const buffer *frame );

--- a/src/switch/datapath/async_event_notifier.c
+++ b/src/switch/datapath/async_event_notifier.c
@@ -163,8 +163,8 @@ save_packet( const buffer *packet ) {
   uint32_t buffer_id = get_buffer_id();
   if ( buffer_id != UINT32_MAX ) {
     packet_in_buffers[ buffer_id ].packet = duplicate_buffer( packet );
-    // duplicate_buffer() copy user_data, which points to old packet addresses
-    duplicate_buffer[ buffer_id ]->user_data = NULL;
+    // duplicate_buffer() copies user_data, which points to old packet addresses
+    copy_packet_info( duplicate_buffer[ buffer_id ]->user_data, packet );
     time_now( &packet_in_buffers[ buffer_id ].saved_at );
   }
 

--- a/src/switch/datapath/async_event_notifier.c
+++ b/src/switch/datapath/async_event_notifier.c
@@ -163,10 +163,8 @@ save_packet( const buffer *packet ) {
   uint32_t buffer_id = get_buffer_id();
   if ( buffer_id != UINT32_MAX ) {
     packet_in_buffers[ buffer_id ].packet = duplicate_buffer( packet );
-    if ( packet->user_data != NULL ) {
-      calloc_packet_info( packet_in_buffers[ buffer_id ].packet );
-      memcpy( packet_in_buffers[ buffer_id ].packet->user_data, packet->user_data, sizeof( packet_info ) );
-    }
+    // duplicate_buffer() copy user_data, which points to old packet addresses
+    duplicate_buffer[ buffer_id ]->user_data = NULL;
     time_now( &packet_in_buffers[ buffer_id ].saved_at );
   }
 

--- a/src/switch/datapath/async_event_notifier.c
+++ b/src/switch/datapath/async_event_notifier.c
@@ -164,7 +164,7 @@ save_packet( const buffer *packet ) {
   if ( buffer_id != UINT32_MAX ) {
     packet_in_buffers[ buffer_id ].packet = duplicate_buffer( packet );
     // duplicate_buffer() copies user_data, which points to old packet addresses
-    copy_packet_info( duplicate_buffer[ buffer_id ]->user_data, packet );
+    copy_packet_info( packet_in_buffers[ buffer_id ].packet, packet );
     time_now( &packet_in_buffers[ buffer_id ].saved_at );
   }
 

--- a/src/switch/datapath/ether_device.c
+++ b/src/switch/datapath/ether_device.c
@@ -342,6 +342,7 @@ receive_frame( int fd, void *user_data ) {
             get_packet_buffers_length( device->recv_queue ), max_queue_length );
       frame = device->recv_buffer; // Use recv_buffer as a trash.
     }
+    reset_buffer( frame );
     append_back_buffer( frame, device->mtu );
 
     ssize_t length = recv( device->fd, frame->data, frame->length, MSG_DONTWAIT );
@@ -361,9 +362,6 @@ receive_frame( int fd, void *user_data ) {
     if ( frame != device->recv_buffer ) {
       frame->length = ( size_t ) length;
       enqueue_packet_buffer( device->recv_queue, frame );
-    }
-    else {
-      reset_buffer( frame );
     }
     count++;
   }


### PR DESCRIPTION
In save_packet(), we store the buffer in packet_in_buffers, duplicate_buffer() does memory copy for us. Unfortunately,
the content of user_data is a set of pointers which points to buffer address. So copying the address will point to old buffer, which will be freed. Fetching by buffer_id and access to user_data causes segmentation fault.
