### PR TITLE
set packet_info->l2_vlan_header

### DIFF
--- a/src/lib/packet_parser.c
+++ b/src/lib/packet_parser.c
@@ -85,6 +85,7 @@ parse_ether( buffer *buf ) {
     packet_info->eth_type = ntohs( vlantag_header->type );
 
     packet_info->format |= ETH_8021Q;
+    packet_info->l2_vlan_header = vlantag_header;
 
     ptr = ( void * ) ( vlantag_header + 1 );
   }


### PR DESCRIPTION
packet_info->l2_vlan_header is referenced by set_vlan_vid(), set_vlan_pcp() and execute_action_pop_vlan() but it is not set in parse_ether().
