### PR TITLE
fix set-vlan byteorder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,8 +83,7 @@ PaperHouse::RubyLibraryTask.new :libruby do | task |
     "#{ Trema.ruby }/trema/messages/*.c"
   ]
   task.includes = Trema.include
-  task.cflags = CFLAGS
-  task.cflags << "-Wno-error=sign-conversion" # FIXME
+  task.cflags = CFLAGS + [ "-Wno-error=sign-conversion" ] # FIXME
   task.ldflags = [ "-Wl,-Bsymbolic", "-L#{ Trema.lib }" ]
   task.library_dependencies = [
     "trema",

--- a/Rakefile
+++ b/Rakefile
@@ -40,8 +40,7 @@ CFLAGS = [
   "-std=gnu99",
   "-D_GNU_SOURCE",
   "-fno-strict-aliasing",
-  # FIXME
-  # "-Werror",
+  "-Werror",
   "-Wall",
   "-Wextra",
   "-Wformat=2",
@@ -85,6 +84,7 @@ PaperHouse::RubyLibraryTask.new :libruby do | task |
   ]
   task.includes = Trema.include
   task.cflags = CFLAGS
+  task.cflags << "-Wno-error=sign-conversion" # FIXME
   task.ldflags = [ "-Wl,-Bsymbolic", "-L#{ Trema.lib }" ]
   task.library_dependencies = [
     "trema",

--- a/ruby/trema/match.c
+++ b/ruby/trema/match.c
@@ -47,6 +47,7 @@ VALUE cMatch;
  */
 static VALUE
 match_from( VALUE self, VALUE message ) {
+  UNUSED( self );
   uint32_t in_port = OFPP_CONTROLLER;
   VALUE r_match = rb_iv_get( message, "@match" );
   if ( !NIL_P( r_match ) ) {

--- a/ruby/trema/unpack-util.c
+++ b/ruby/trema/unpack-util.c
@@ -548,7 +548,7 @@ static void
 unpack_action_set_field( const struct ofp_action_set_field *src, VALUE r_action_ary ) {
   VALUE r_attributes = rb_hash_new();
   VALUE r_flexible_action = Qnil;
-  uint32_t field_length = src->len - offsetof( struct ofp_action_set_field, field );
+  uint16_t field_length = ( uint16_t ) ( src->len - offsetof( struct ofp_action_set_field, field ) );
 
   if ( field_length > sizeof( oxm_match_header ) ) {
     const oxm_match_header *oxm_src = ( const oxm_match_header * ) src->field;

--- a/src/switch/datapath/action_executor.c
+++ b/src/switch/datapath/action_executor.c
@@ -347,7 +347,7 @@ set_vlan_vid( buffer *frame, uint16_t value ) {
   }
 
   vlantag_header_t *header = info->l2_vlan_header;
-  header->tci = ( uint16_t ) ( ( header->tci & htons( 0xf000 ) ) | ( value & 0x0fff ) );
+  header->tci = ( uint16_t ) ( ( header->tci & htons( 0xf000 ) ) | htons( value & 0x0fff ) );
 
   return parse_frame( frame );
 }
@@ -365,7 +365,7 @@ set_vlan_pcp( buffer *frame, uint8_t value ) {
   }
 
   vlantag_header_t *header = info->l2_vlan_header;
-  header->tci = ( uint16_t ) ( ( header->tci & htons( 0x1fff ) ) | ( ( value & 0x07 ) << 5 ) );
+  header->tci = ( uint16_t ) ( ( header->tci & htons( 0x1fff ) ) | htons( ( value & 0x07 ) << 13 ) );
 
   return parse_frame( frame );
 }

--- a/src/switch_manager/tls.c
+++ b/src/switch_manager/tls.c
@@ -124,7 +124,7 @@ init_tls_server( const char *cert_file, const char *key_file ) {
   SSL_library_init();
   SSL_load_error_strings();
 
-  SSL_METHOD *method = TLSv1_server_method();
+  const SSL_METHOD *method = TLSv1_server_method();
   ctx = SSL_CTX_new( method );
   if ( ctx == NULL ) {
     unsigned long error_no = ERR_get_error();

--- a/vendor/phost/src/cli.c
+++ b/vendor/phost/src/cli.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -1026,7 +1027,7 @@ int cli_parse_show_stats(int argc, char **argv)
                    ntohl(reply.st[i].rip), ntohs(reply.st[i].rport),
                    ntohl(reply.st[i].n_pkts), ntohll(reply.st[i].n_octets));
 */
-            printf("%s,%u,%s,%u,%u,%llu\n",
+            printf("%s,%u,%s,%u,%u,%"PRIu64"\n",
                    ultoipaddr(ntohl(reply.st[i].lip), lip_addr),
                    ntohs(reply.st[i].lport),
                    ultoipaddr(ntohl(reply.st[i].rip), rip_addr),

--- a/vendor/phost/src/cmdif.c
+++ b/vendor/phost/src/cmdif.c
@@ -255,7 +255,7 @@ int cmdif_send_packets(cmdif_request_send_packets *request)
         reply.duration_sec = 0;
         reply.duration_usec = 0;
         length = sizeof(reply);
-        cmdif_send((void*)&reply, &length);
+        cmdif_send((void*)&reply, (uint32_t*)&length);
     }
 
     return ret;

--- a/vendor/phost/src/trx.c
+++ b/vendor/phost/src/trx.c
@@ -479,15 +479,16 @@ int trx_rx()
 
 int trx_rx_one()
 {
+    int ret;
     uint32_t length = 0;
     uint8_t *buffer;
 
     buffer = (uint8_t *)malloc(sizeof(uint8_t)*PKT_BUF_SIZE);
     memset(buffer, 0, sizeof(uint8_t)*PKT_BUF_SIZE);
 
-    trx_read(buffer, &length);
+    ret = trx_read(buffer, &length);
 
-    if(length <= 0){
+    if(ret < 0 || length <= 0){
         free(buffer);
         return -1;
     }


### PR DESCRIPTION
bytes in a frame are stored in network byte order. vlan priority bit shifts was wrong.
