### PR TITLE
pcap library capture support

### DIFF
--- a/src/switch/datapath/action_executor.c
+++ b/src/switch/datapath/action_executor.c
@@ -1115,11 +1115,11 @@ execute_action_push_mpls( buffer *frame, action *push_mpls ) {
   }
   else if ( packet_type_ipv4( frame ) ) {
     ipv4_header_t *ipv4_header = info->l3_header;
-    default_mpls = htonl( 0x00000100 | ipv4_header->ttl );
+    default_mpls = htonl( 0x00000100 | ( uint32_t ) ipv4_header->ttl );
   }
   else if ( packet_type_ipv6( frame ) ) {
     ipv6_header_t *ipv6_header = info->l3_header;
-    default_mpls = htonl( 0x00000100 | ipv6_header->hoplimit );
+    default_mpls = htonl( 0x00000100 | ( uint32_t ) ipv6_header->hoplimit );
   }
 
   uint32_t *mpls = push_mpls_tag( frame, start );

--- a/src/switch/datapath/ether_device.c
+++ b/src/switch/datapath/ether_device.c
@@ -416,7 +416,6 @@ flush_send_queue( int fd, void *user_data ) {
     if( pcap_sendpacket( device->pcap, buf->data, buf->length ) < 0 ){
       error( "Failed to send a message to ethernet device ( device = %s, pcap_err = %s ).",
         device->name, pcap_geterr( device->pcap ) );
-      return;
     }
     ssize_t length = buf->length;
 #else

--- a/src/switch/datapath/ether_device.c
+++ b/src/switch/datapath/ether_device.c
@@ -345,6 +345,29 @@ receive_frame( int fd, void *user_data ) {
     reset_buffer( frame );
     append_back_buffer( frame, device->mtu );
 
+#if WITH_PCAP
+    ssize_t length = 0;
+    struct pcap_pkthdr *header = NULL;
+    const u_char *packet = NULL;
+    int ret = pcap_next_ex( device->pcap, &header, &packet );
+    if ( ret == 1 ) {
+      length = header->caplen;
+      if ( length > frame->length ) {
+        append_back_buffer( frame, length - frame->length );
+      }
+      memcpy( frame->data, packet, length );
+    }
+    else {
+      if ( frame != device->recv_buffer ) {
+        mark_packet_buffer_as_used( device->recv_queue, frame );
+      }
+      if ( ret == -1 ) {
+        error( "Receive error ( device = %s, pcap_err = %s ).",
+             device->name, pcap_geterr( device->pcap ) );
+      }
+      break;
+    }
+#else // WITH_PCAP
     ssize_t length = recv( device->fd, frame->data, frame->length, MSG_DONTWAIT );
     assert( length != 0 );
     if ( length < 0 ) {
@@ -359,6 +382,7 @@ receive_frame( int fd, void *user_data ) {
              device->name, safe_strerror_r( errno, error_string, sizeof( error_string ) ), errno );
       break;
     }
+#endif
     if ( frame != device->recv_buffer ) {
       frame->length = ( size_t ) length;
       enqueue_packet_buffer( device->recv_queue, frame );
@@ -388,6 +412,14 @@ flush_send_queue( int fd, void *user_data ) {
   int count = 0;
   buffer *buf = NULL;
   while ( ( buf = peek_packet_buffer( device->send_queue ) ) != NULL && count < 256 ) {
+#if WITH_PCAP
+    if( pcap_sendpacket( device->pcap, buf->data, buf->length ) < 0 ){
+      error( "Failed to send a message to ethernet device ( device = %s, pcap_err = %s ).",
+        device->name, pcap_geterr( device->pcap ) );
+      return;
+    }
+    ssize_t length = buf->length;
+#else
     ssize_t length = sendto( device->fd, buf->data, buf->length, MSG_DONTWAIT, ( struct sockaddr * ) &sll, sizeof( sll ) );
     if ( length < 0 ) {
       if ( ( errno == EINTR ) || ( errno == EAGAIN ) || ( errno == EWOULDBLOCK ) ) {
@@ -398,6 +430,7 @@ flush_send_queue( int fd, void *user_data ) {
              device->name, safe_strerror_r( errno, error_string, sizeof( error_string ) ), errno );
       return;
     }
+#endif
 
     if ( ( size_t ) length < buf->length ) {
       remove_front_buffer( buf, ( size_t ) length );
@@ -464,6 +497,15 @@ create_ether_device( const char *name, const size_t max_send_queue, const size_t
 
   close( nfd );
 
+#ifdef WITH_PCAP
+  char errbuf[ PCAP_ERRBUF_SIZE ];
+  pcap_t *handle = pcap_open_live( name, BUFSIZ, 1, 100, errbuf );
+  if( handle == NULL ){
+    error( "device %s open failed %s", name, errbuf );
+    return NULL;
+  }
+  int fd = pcap_get_selectable_fd( handle );
+#else // WITH_PCAP
   int fd = socket( PF_PACKET, SOCK_RAW, htons( ETH_P_ALL ) );
   if ( fd < 0 ) {
     char error_string[ ERROR_STRING_SIZE ];
@@ -493,11 +535,15 @@ create_ether_device( const char *name, const size_t max_send_queue, const size_t
       break;
     }
   }
+#endif // WITH_PCAP
 
   ether_device *device = xmalloc( sizeof( ether_device ) );
   memset( device, 0, sizeof( ether_device ) );
   strncpy( device->name, name, IFNAMSIZ );
   device->name[ IFNAMSIZ - 1 ] = '\0';
+#if WITH_PCAP
+  device->pcap = handle;
+#endif
   device->fd = fd;
   device->ifindex = ifindex;
   memcpy( device->hw_addr, ifr.ifr_hwaddr.sa_data, ETH_ADDRLEN );
@@ -528,6 +574,12 @@ void
 delete_ether_device( ether_device *device ) {
   assert( device != NULL );
 
+#if WITH_PCAP
+  if ( device->pcap != NULL ) {
+    pcap_close( device->pcap );
+    device->pcap = NULL;
+  }
+#endif
   if ( device->fd >= 0 ) {
     set_readable_safe( device->fd, false );
     if ( get_packet_buffers_length( device->send_queue ) > 0 ) {
@@ -652,7 +704,7 @@ send_frame( ether_device *device, buffer *frame ) {
 
   debug( "Enqueueing a frame to send queue ( frame = %p, device = %s, queue length = %d, fd = %d ).",
          frame, device->name, get_packet_buffers_length( device->send_queue ), device->fd );
-  
+
   buffer *copy = get_free_packet_buffer( device->send_queue );
   assert( copy != NULL );
   copy_buffer( copy, frame );

--- a/src/switch/datapath/ether_device.h
+++ b/src/switch/datapath/ether_device.h
@@ -22,6 +22,9 @@
 
 #include <net/if.h>
 #include <stdint.h>
+#if WITH_PCAP
+#include <pcap.h>
+#endif
 #include "ofdp_common.h"
 #include "packet_buffer.h"
 
@@ -59,6 +62,9 @@ typedef struct {
     uint64_t rx_crc_err;
     uint64_t collisions;
   } stats;
+#if WITH_PCAP
+  pcap_t *pcap;
+#endif
   int fd;
   packet_buffers *send_queue;
   packet_buffers *recv_queue;

--- a/src/switch/switch/datapath.c
+++ b/src/switch/switch/datapath.c
@@ -213,7 +213,7 @@ void set_event_handlers( void *user_data ) {
 
 static void
 dump_flows_actually() {
-  dump_flow_table( 0, info );
+  dump_flow_tables( info );
 }
 
 


### PR DESCRIPTION
In some cases SOCK_RAW does not capture vlan tag, and generates a stripped packet. This happens on recent linux which has PACKET_AUXDATA in <linux/if_packet.h>. Compiling with -DWITH_PCAP -lpcap will create a libpcap enabled version of trema switch.
