### PR TITLE
reduce memory usage

### DIFF
--- a/src/lib/messenger.c
+++ b/src/lib/messenger.c
@@ -271,9 +271,9 @@ init_messenger( const char *working_directory ) {
 
   strcpy( socket_directory, working_directory );
 
-  receive_queues = create_hash( compare_string, hash_string );
-  send_queues = create_hash( compare_string, hash_string );
-  context_db = create_hash( compare_uint32, hash_uint32 );
+  receive_queues = create_hash_with_size( compare_string, hash_string, 8 );
+  send_queues = create_hash_with_size( compare_string, hash_string, 8 );
+  context_db = create_hash_with_size( compare_uint32, hash_uint32, 128 );
 
   initialized = true;
   finalized = false;

--- a/src/lib/openflow_switch_interface.c
+++ b/src/lib/openflow_switch_interface.c
@@ -216,7 +216,7 @@ static void
 init_context() {
   assert( contexts == NULL );
 
-  contexts = create_hash_with_size( compare_context, hash_context, 16 );
+  contexts = create_hash_with_size( compare_context, hash_context, 128 );
 }
 
 


### PR DESCRIPTION
create_hash allocates default_hash_size=65521, and that is too much for the following variables for switch implementation.

in messenger.c
- receive_queues : key is service_name
- send_queus : key is serviece_name
- context_db : not used

active transaction id with hash size 16 is small.

in openflow_switch_interface.c
- contexts : key is xid
