### PR TITLE
Fix build error with GCC 4.8.1

### DIFF
--- a/src/switch/datapath/flow_table.c
+++ b/src/switch/datapath/flow_table.c
@@ -315,7 +315,7 @@ init_flow_table( const uint8_t table_id, const uint32_t max_flow_entries ) {
     return OFDPE_FAILED;
   }
 
-  memset( table, 0, sizeof( table ) );
+  memset( table, 0, sizeof( flow_table ) );
 
   table->counters.active_count = 0;
   table->counters.lookup_count = 0;


### PR DESCRIPTION
other functions are using "sizeof( flow_table )". 
I have rewritten follow it.
- reference: http://gcc.gnu.org/gcc-4.8/porting_to.html
  
  > The behavior of -Wall has changed and now includes the new warning flag -Wsizeof-pointer-memaccess.
- environment:

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=13.10
DISTRIB_CODENAME=saucy
DISTRIB_DESCRIPTION="Ubuntu 13.10"
$ gcc --version
gcc (Ubuntu/Linaro 4.8.1-10ubuntu8) 4.8.1
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
- build log:

```
(snip)
/home/kaishuu0123/trema-edge/src/switch/datapath/flow_table.c: In function ‘init_flow_table’:
/home/kouki-o/trema-edge/src/switch/datapath/flow_table.c:318:27: error: argument to ‘sizeof’ in ‘memset’ call is the same expression as the destination; did you mean to dereference it? [-Werror=sizeof-pointer-memaccess]
   memset( table, 0, sizeof( table ) );
                           ^
rake aborted!
gcc failed
```
