### PR TITLE
Fix pbb mpls parsing

### DIFF
--- a/src/lib/packet_parser.c
+++ b/src/lib/packet_parser.c
@@ -109,23 +109,6 @@ parse_ether( buffer *buf ) {
         ptr = ( void * ) ( vlantag_header + 1 );
         tagged = 1;
       }
-      else if ( ethertype == ETH_ETHTYPE_PBB ) {
-        if ( length < sizeof( pbb_header_t ) ) {
-          debug("incomplete pbb_header_t");
-          return;
-        }
-        pbb_header_t *pbb_header = ptr;
-
-        if ( packet_info->l2_pbb_header == NULL ) {
-          // capture the outermost information
-          packet_info->pbb_isid = ntohl( pbb_header->isid ) & 0x00FFFFFF;
-          packet_info->l2_pbb_header = pbb_header;
-        }
-
-        ethertype = ntohs( pbb_header->type );
-        ptr = ( void * ) ( pbb_header + 1 );
-        tagged = 1;
-      }
     }
   } while ( tagged == 1 );
 
@@ -346,37 +329,46 @@ parse_mpls( buffer *buf ) {
   assert( buf != NULL );
 
   packet_info *packet_info = buf->user_data;
-  void *ptr = packet_info->l3_header;
+  void *ptr = packet_info->l2_payload;
   assert( ptr != NULL );
 
-  uint8_t mpls_bos = 0;
-  do {
-    // Check the length of remained buffer
-    size_t length = REMAINED_BUFFER_LENGTH( buf, ptr );
-    if ( length < sizeof( mpls_header_t ) ) {
-      debug("incomplete mpls");
-      return;
-    }
-
-    mpls_header_t *mpls_header = ptr;
-    uint32_t mpls = ntohl( mpls_header->label );
-    mpls_bos = ( uint8_t ) ( ( mpls & 0x00000100 ) >> 8 );
-    if ( packet_info->l2_mpls_header == NULL ) {
-      // capture the outermost information
-      packet_info->mpls_label =             ( ( mpls & 0xFFFFF000 ) >> 12 );
-      packet_info->mpls_tc    = ( uint8_t ) ( ( mpls & 0x00000E00 ) >>  9 );
-      packet_info->mpls_bos   = ( uint8_t ) ( ( mpls & 0x00000100 ) >>  8 );
-      packet_info->format |= MPLS;
-      packet_info->l2_mpls_header = ptr;
-    }
-    ptr = ( void * ) ( mpls_header + 1 );
-  } while ( mpls_bos == 0 );
-
-  size_t payload_length = REMAINED_BUFFER_LENGTH( buf, ptr );
-  if ( payload_length > 0 ) {
-    packet_info->l3_payload = ptr;
-    packet_info->l3_payload_length = payload_length;
+  // Check the length of remained buffer
+  size_t length = REMAINED_BUFFER_LENGTH( buf, ptr );
+  if ( length < sizeof( mpls_header_t ) ) {
+    debug("incomplete mpls");
+    return;
   }
+
+  // We only parse the outer most one.
+  mpls_header_t *mpls_header = ptr;
+  uint32_t mpls = ntohl( mpls_header->label );
+  packet_info->mpls_label =             ( ( mpls & 0xFFFFF000 ) >> 12 );
+  packet_info->mpls_tc    = ( uint8_t ) ( ( mpls & 0x00000E00 ) >>  9 );
+  packet_info->mpls_bos   = ( uint8_t ) ( ( mpls & 0x00000100 ) >>  8 );
+  packet_info->format |= MPLS;
+  packet_info->l2_mpls_header = ptr;
+
+  return;
+}
+
+
+static void
+parse_pbb( buffer *buf ) {
+  assert( buf != NULL );
+
+  packet_info *packet_info = buf->user_data;
+  void *ptr = packet_info->l2_payload;
+  assert( ptr != NULL );
+
+  // Check the length of remained buffer
+  size_t length = REMAINED_BUFFER_LENGTH( buf, ptr );
+  if ( length < sizeof( pbb_header_t ) ) {
+    debug("incomplete pbb_header_t");
+    return;
+  }
+
+  pbb_header_t *pbb_header = ptr;
+  packet_info->pbb_isid = ntohl( pbb_header->isid ) & 0x00FFFFFF;
 
   return;
 }
@@ -706,9 +698,12 @@ parse_packet( buffer *buf ) {
 
   case ETH_ETHTYPE_MPLS_UNI:
   case ETH_ETHTYPE_MPLS_MLT:
-    packet_info->l3_header = packet_info->l2_payload;
     parse_mpls( buf );
-    break;
+    return true;
+
+  case ETH_ETHTYPE_PBB:
+    parse_pbb( buf );
+    return true;
 
   default:
     // Unknown L3 type

--- a/src/switch/switch/oxm-helper.c
+++ b/src/switch/switch/oxm-helper.c
@@ -285,6 +285,20 @@ assign_metadata( const oxm_match_header *hdr, match *match ) {
 
 
 static void
+assign_pbb_isid( const oxm_match_header *hdr, match *match ) {
+  const uint32_t *value = ( const uint32_t * ) ( ( const char * ) hdr + sizeof( oxm_match_header ) );
+
+  if ( *hdr == OXM_OF_PBB_ISID ) {
+    MATCH_ATTR_SET( pbb_isid, (*value & 0xffffff));
+  }
+  if ( *hdr == OXM_OF_PBB_ISID_W ) {
+    const uint32_t *mask = ( const uint32_t * ) ( ( const char * ) value + sizeof ( uint32_t ) );
+    MATCH_ATTR_MASK_SET( pbb_isid, (*value & 0xffffff), (*mask & 0xffffff));
+  }
+}
+
+
+static void
 _assign_match( match *match, const oxm_match_header *hdr ) {
   switch( *hdr ) {
     case OXM_OF_IN_PORT: {
@@ -447,6 +461,11 @@ _assign_match( match *match, const oxm_match_header *hdr ) {
       assign_ipv6_exthdr( hdr, match );
     }
     break;
+    case OXM_OF_PBB_ISID:
+    case OXM_OF_PBB_ISID_W: {
+      assign_pbb_isid( hdr, match );
+    }
+    break;
     default:
       error( "Undefined oxm type ( header = %#x, type = %#x, has_mask = %u, length = %u ). ",
               *hdr, OXM_TYPE( *hdr ), OXM_HASMASK( *hdr ), OXM_LENGTH( *hdr ) );
@@ -553,6 +572,9 @@ _construct_oxm( oxm_matches *oxm_match, match *match ) {
   }
   APPEND_OXM_MATCH( udp_dst )
   APPEND_OXM_MATCH( udp_src )
+  if ( match->pbb_isid.valid ) {
+    append_oxm_match_pbb_isid( oxm_match, match->pbb_isid.value, match->pbb_isid.mask );
+  }
 }
 void ( *construct_oxm )( oxm_matches *oxm_match, match *match ) = _construct_oxm;
 


### PR DESCRIPTION
With PBB or MPLS, we would keep ETH_TYPE persistent and should not go into parsing the inner frame.
