### PR TITLE
Fix PBB_ISID bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,6 @@ To stop the controller
 - added macro
     - `OFP_DEFAULT_PRIORITY`
     - `OFP_DEFAULT_MISS_SEND_LEN`
-- data length of the OXM TLV
-    - `OXM_OF_IPV6_FLABEL` 20bits is 4bytes
-    - `OXM_OF_MPLS_LABEL` 20bits is 4bytes
-    - `OXM_OF_PBB_ISID` 24bits is 4bytes
 
 
 License

--- a/src/lib/openflow_message.c
+++ b/src/lib/openflow_message.c
@@ -8295,6 +8295,17 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
     }
     append_oxm_match_eth_dst( match, ( ( packet_info * ) packet->user_data )->eth_macda, tmp_mac_mask );
   }
+  if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_PBB_ISID ) ) ) {
+    uint32_t pbb_isid;
+    if ( packet_type_eth_pbb( packet ) ) {
+      pbb_isid = ( ( packet_info * ) packet->user_data )->pbb_isid;
+      if ( ( pbb_isid & ~PBB_ISID_MASK ) != 0 ) {
+        warn( "Invalid pbb_isid ( change %#x to %#x )", pbb_isid, pbb_isid & PBB_ISID_MASK );
+        pbb_isid = ( uint32_t ) ( pbb_isid & PBB_ISID_MASK );
+      }
+    }
+    append_oxm_match_pbb_isid( match, pbb_isid, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_pbb_isid ) );
+  }
   if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_VLAN_VID ) ) ) {
     uint16_t vlan_vid;
     if ( packet_type_eth_vtag( packet ) ) {

--- a/src/lib/oxm_byteorder.c
+++ b/src/lib/oxm_byteorder.c
@@ -428,11 +428,13 @@ void hton_oxm_match_pbb_isid( oxm_match_header *dst, const oxm_match_header *src
   assert( src != NULL );
   assert( *src == OXM_OF_PBB_ISID || *src == OXM_OF_PBB_ISID_W );
 
+  hton_oxm_match_header( dst, src );
   if ( OXM_HASMASK( *src ) ) {
-    return hton_oxm_match_32w( dst, src );
+    memcpy(( ( char * ) dst + sizeof( oxm_match_header ) ), ( ( char * ) src + sizeof( oxm_match_header ) ), 6);
   }
-
-  hton_oxm_match_32( dst, src );
+  else {
+    memcpy(( ( char * ) dst + sizeof( oxm_match_header ) ), ( ( char * ) src + sizeof( oxm_match_header ) ), 3);
+  }
 }
 
 
@@ -1022,14 +1024,15 @@ void ntoh_oxm_match_pbb_isid( oxm_match_header *dst, const oxm_match_header *src
   assert( dst != NULL );
   assert( src != NULL );
 
+  ntoh_oxm_match_header( dst, src );
   if ( OXM_HASMASK( ntohl( *src ) ) ) {
-    ntoh_oxm_match_32w( dst, src );
     assert( *dst == OXM_OF_PBB_ISID_W );
-    return;
+    memcpy(( ( char * ) dst + sizeof( oxm_match_header ) ), ( ( char * ) src + sizeof( oxm_match_header ) ), 6);
   }
-
-  ntoh_oxm_match_32( dst, src );
-  assert( *dst == OXM_OF_PBB_ISID );
+  else {
+    assert( *dst == OXM_OF_PBB_ISID );
+    memcpy(( ( char * ) dst + sizeof( oxm_match_header ) ), ( ( char * ) src + sizeof( oxm_match_header ) ), 3);
+  }
 }
 
 

--- a/src/lib/oxm_match.c
+++ b/src/lib/oxm_match.c
@@ -158,6 +158,35 @@ append_oxm_match_16w( oxm_matches *matches, oxm_match_header header, uint16_t va
 
 
 static bool
+append_oxm_match_24( oxm_matches *matches, oxm_match_header header, uint32_t value ) {
+  assert( matches != NULL );
+  assert( OXM_LENGTH( header ) == 3 );
+
+  oxm_match_header *buf = xmalloc( sizeof( oxm_match_header ) + 3 );
+  *buf = header;
+  uint32_t *v = ( uint32_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
+  *v = ( *v & 0xF000 ) | ( value & 0x0FFF );
+
+  return append_oxm_match( matches, buf );
+}
+
+
+static bool
+append_oxm_match_24w( oxm_matches *matches, oxm_match_header header, uint32_t value, uint32_t mask ) {
+  assert( matches != NULL );
+  assert( OXM_LENGTH( header ) == ( 3 * 2 ) );
+
+  oxm_match_header *buf = xmalloc( sizeof( oxm_match_header ) + 3 * 2 );
+  *buf = header;
+  uint32_t *v = ( uint32_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
+  *v = ( *v & 0xF000 ) | ( value & 0x0FFF );
+  v = ( uint32_t * ) ( ( char * ) v + sizeof( uint32_t ) );
+  *v = ( *v & 0xF000 ) | ( mask & 0x0FFF );
+
+  return append_oxm_match( matches, buf );
+}
+
+static bool
 append_oxm_match_32( oxm_matches *matches, oxm_match_header header, uint32_t value ) {
   assert( matches != NULL );
   assert( OXM_LENGTH( header ) == sizeof( uint32_t ) );
@@ -629,10 +658,10 @@ append_oxm_match_pbb_isid( oxm_matches *matches, uint32_t value, uint32_t mask )
   assert( matches != NULL );
 
   if ( mask == UINT32_MAX ) {
-    return append_oxm_match_32( matches, OXM_OF_PBB_ISID, value );
+    return append_oxm_match_24( matches, OXM_OF_PBB_ISID, value );
   }
 
-  return append_oxm_match_32w( matches, OXM_OF_PBB_ISID_W, value, mask );
+  return append_oxm_match_24w( matches, OXM_OF_PBB_ISID_W, value, mask );
 }
 
 

--- a/src/lib/oxm_match.c
+++ b/src/lib/oxm_match.c
@@ -164,8 +164,10 @@ append_oxm_match_24( oxm_matches *matches, oxm_match_header header, uint32_t val
 
   oxm_match_header *buf = xmalloc( sizeof( oxm_match_header ) + 3 );
   *buf = header;
-  uint32_t *v = ( uint32_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
-  *v = ( *v & 0xF000 ) | ( value & 0x0FFF );
+  uint8_t *v = ( uint8_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
+  v[ 0 ] = ( uint8_t ) ( value >> 16 ) & 0xFF;
+  v[ 1 ] = ( uint8_t ) ( value >>  8 ) & 0xFF;
+  v[ 2 ] = ( uint8_t ) ( value >>  0 ) & 0xFF;
 
   return append_oxm_match( matches, buf );
 }
@@ -178,10 +180,13 @@ append_oxm_match_24w( oxm_matches *matches, oxm_match_header header, uint32_t va
 
   oxm_match_header *buf = xmalloc( sizeof( oxm_match_header ) + 3 * 2 );
   *buf = header;
-  uint32_t *v = ( uint32_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
-  *v = ( *v & 0xF000 ) | ( value & 0x0FFF );
-  v = ( uint32_t * ) ( ( char * ) v + sizeof( uint32_t ) );
-  *v = ( *v & 0xF000 ) | ( mask & 0x0FFF );
+  uint8_t *v = ( uint8_t * ) ( ( char * ) buf + sizeof( oxm_match_header ) );
+  v[ 0 ] = ( uint8_t ) ( value >> 16 ) & 0xFF;
+  v[ 1 ] = ( uint8_t ) ( value >>  8 ) & 0xFF;
+  v[ 2 ] = ( uint8_t ) ( value >>  0 ) & 0xFF;
+  v[ 3 ] = ( uint8_t ) ( mask  >> 16 ) & 0xFF;
+  v[ 4 ] = ( uint8_t ) ( mask  >>  8 ) & 0xFF;
+  v[ 5 ] = ( uint8_t ) ( mask  >>  0 ) & 0xFF;
 
   return append_oxm_match( matches, buf );
 }

--- a/src/lib/packet_info.c
+++ b/src/lib/packet_info.c
@@ -157,6 +157,13 @@ packet_type_eth_mpls( const buffer *frame ) {
 
 
 bool
+packet_type_eth_pbb( const buffer *frame ) {
+  die_if_NULL( frame );
+  return if_packet_type( frame, PBB );
+}
+
+
+bool
 packet_type_arp( const buffer *frame ) {
   die_if_NULL( frame );
   return if_packet_type( frame, NW_ARP );

--- a/src/lib/packet_info.h
+++ b/src/lib/packet_info.h
@@ -46,6 +46,7 @@ enum {
   ETH_8023_SNAP = 0x00000008,
   ETH_8021Q = 0x00000010,
   MPLS = 0x00000020,
+  PBB = 0x00000040,
   NW_IPV4 = 0x00000100,
   NW_ICMPV4 = 0x00000200,
   NW_IPV6 = 0x00000400,
@@ -247,6 +248,7 @@ bool packet_type_eth_raw( const buffer *frame );
 bool packet_type_eth_llc( const buffer *frame );
 bool packet_type_eth_snap( const buffer *frame );
 bool packet_type_eth_mpls( const buffer *frame );
+bool packet_type_eth_pbb(const buffer *frame);
 bool packet_type_ether( const buffer *frame );
 bool packet_type_arp( const buffer *frame );
 bool packet_type_ipv4( const buffer *frame );

--- a/src/lib/packet_parser.c
+++ b/src/lib/packet_parser.c
@@ -369,6 +369,8 @@ parse_pbb( buffer *buf ) {
 
   pbb_header_t *pbb_header = ptr;
   packet_info->pbb_isid = ntohl( pbb_header->isid ) & 0x00FFFFFF;
+  packet_info->l2_pbb_header = ptr;
+  packet_info->format |= PBB;
 
   return;
 }

--- a/src/lib/utility.c
+++ b/src/lib/utility.c
@@ -215,6 +215,74 @@ oxm_match_16w_to_hex_string( const oxm_match_header *header, char *str, size_t l
 
 
 static bool
+oxm_match_24_to_dec_string( const oxm_match_header *header, char *str, size_t length, const char *key ) {
+  assert( header != NULL );
+  assert( str != NULL );
+  assert( length > 0 );
+  assert( key != NULL );
+
+  const uint8_t *v = ( const uint8_t * ) ( ( const char * ) header + sizeof( oxm_match_header ) );
+  int ret = snprintf( str, length, "%s = %u", key, (v[0]<<16)+(v[1]<<8)+v[2] );
+  if ( ( ret >= ( int ) length ) || ( ret < 0 ) ) {
+    return false;
+  }
+
+  return true;
+}
+
+
+static bool
+oxm_match_24_to_hex_string( const oxm_match_header *header, char *str, size_t length, const char *key ) {
+  assert( header != NULL );
+  assert( str != NULL );
+  assert( length > 0 );
+  assert( key != NULL );
+
+  const uint8_t *v = ( const uint8_t * ) ( ( const char * ) header + sizeof( oxm_match_header ) );
+  int ret = snprintf( str, length, "%s = 0x%06x", key, (v[0]<<16)+(v[1]<<8)+v[2] );
+  if ( ( ret >= ( int ) length ) || ( ret < 0 ) ) {
+    return false;
+  }
+
+  return true;
+}
+
+
+static bool
+oxm_match_24w_to_dec_string( const oxm_match_header *header, char *str, size_t length, const char *key ) {
+  assert( header != NULL );
+  assert( str != NULL );
+  assert( length > 0 );
+  assert( key != NULL );
+
+  const uint8_t *v = ( const uint8_t * ) ( ( const char * ) header + sizeof( oxm_match_header ) );
+  int ret = snprintf( str, length, "%s = %u/%u", key, (v[0]<<16)+(v[1]<<8)+v[2], (v[3]<<16)+(v[4]<<8)+v[5] );
+  if ( ( ret >= ( int ) length ) || ( ret < 0 ) ) {
+    return false;
+  }
+
+  return true;
+}
+
+
+static bool
+oxm_match_24w_to_hex_string( const oxm_match_header *header, char *str, size_t length, const char *key ) {
+  assert( header != NULL );
+  assert( str != NULL );
+  assert( length > 0 );
+  assert( key != NULL );
+
+  const uint8_t *v = ( const uint8_t * ) ( ( const char * ) header + sizeof( oxm_match_header ) );
+  int ret = snprintf( str, length, "%s = 0x%06x/0x%06x", key, (v[0]<<16)+(v[1]<<8)+v[2], (v[3]<<16)+(v[4]<<8)+v[5] );
+  if ( ( ret >= ( int ) length ) || ( ret < 0 ) ) {
+    return false;
+  }
+
+  return true;
+}
+
+
+static bool
 oxm_match_32_to_dec_string( const oxm_match_header *header, char *str, size_t length, const char *key ) {
   assert( header != NULL );
   assert( str != NULL );
@@ -900,10 +968,10 @@ oxm_match_pbb_isid_to_string( const oxm_match_header *header, char *str, size_t 
 
   switch ( *header ) {
     case OXM_OF_PBB_ISID:
-      return oxm_match_32_to_hex_string( header, str, length, "pbb_isid" );
+      return oxm_match_24_to_hex_string( header, str, length, "pbb_isid" );
 
     case OXM_OF_PBB_ISID_W:
-      return oxm_match_32w_to_hex_string( header, str, length, "pbb_isid" );
+      return oxm_match_24w_to_hex_string( header, str, length, "pbb_isid" );
 
     default:
       assert( 0 );

--- a/src/switch/switch/oxm-helper.c
+++ b/src/switch/switch/oxm-helper.c
@@ -286,14 +286,14 @@ assign_metadata( const oxm_match_header *hdr, match *match ) {
 
 static void
 assign_pbb_isid( const oxm_match_header *hdr, match *match ) {
-  const uint32_t *value = ( const uint32_t * ) ( ( const char * ) hdr + sizeof( oxm_match_header ) );
+  const uint8_t *v = ( const uint8_t * ) ( ( const char * ) hdr + sizeof( oxm_match_header ) );
 
+  uint32_t value = ( v[ 0 ] << 16 ) + ( v[ 1 ] << 8 ) + v[ 2 ];
   if ( *hdr == OXM_OF_PBB_ISID ) {
-    MATCH_ATTR_SET( pbb_isid, (*value & 0xffffff));
+    MATCH_ATTR_SET( pbb_isid, value );
   }
-  if ( *hdr == OXM_OF_PBB_ISID_W ) {
-    const uint32_t *mask = ( const uint32_t * ) ( ( const char * ) value + sizeof ( uint32_t ) );
-    MATCH_ATTR_MASK_SET( pbb_isid, (*value & 0xffffff), (*mask & 0xffffff));
+  else if ( *hdr == OXM_OF_PBB_ISID_W ) {
+    MATCH_ATTR_MASK_SET( pbb_isid, value, ( v[ 3 ] << 16 ) + ( v[ 4 ] << 8 ) + v[ 5 ] );
   }
 }
 

--- a/src/switch/switch/oxm-pbb-isid.c
+++ b/src/switch/switch/oxm-pbb-isid.c
@@ -59,6 +59,10 @@ pbb_isid_length( const match *match ) {
   
   if ( match->pbb_isid.valid ) {
     length = oxm_pbb_isid.length;
+
+    if( match->pbb_isid.mask != UINT32_MAX ){
+      length = ( uint16_t ) ( length * 2);
+    }
   }
   return length;
 }
@@ -68,8 +72,10 @@ static uint16_t
 pack_pbb_isid( oxm_match_header *hdr, const match *match ) {
   if ( match->pbb_isid.valid ) {
     *hdr = OXM_OF_PBB_ISID;
-    uint32_t *value = ( uint32_t * ) ( ( char * ) hdr + sizeof ( oxm_match_header ) );
-    *value = match->pbb_isid.value;
+    uint8_t *value = ( uint8_t * ) ( ( char * ) hdr + sizeof ( oxm_match_header ) );
+    value[ 0 ] = ( match->pbb_isid.value >> 16 ) & 0xFF;
+    value[ 1 ] = ( match->pbb_isid.value >>  8 ) & 0xFF;
+    value[ 2 ] = ( match->pbb_isid.value >>  0 ) & 0xFF;
     return oxm_pbb_isid.length;
   }
   return 0;


### PR DESCRIPTION
As of openflow 1.3.3 spec:
- data length of the OXM TLV
  - `OXM_OF_IPV6_FLABEL` 20bits is 4bytes
  - `OXM_OF_MPLS_LABEL` 20bits is 4bytes
  - `OXM_OF_PBB_ISID` 24bits is 3bytes
