### PR TITLE
fix packet struct alignment def.

### DIFF
--- a/src/lib/ether.h
+++ b/src/lib/ether.h
@@ -54,6 +54,7 @@
 #define ETH_ETHTYPE_MPLS_MLT 0x8848
 #define ETH_ETHTYPE_UKNOWN 0xffff
 
+#pragma pack(1)
 
 typedef struct ether_headr {
   uint8_t macda[ ETH_ADDRLEN ];
@@ -83,6 +84,7 @@ typedef struct snap_header {
   uint16_t type;
 } snap_header_t;
 
+#pragma pack()
 
 #define TCI_GET_PRIO( _tci ) ( uint8_t )( ( ( _tci ) >> 13 ) & 7 )
 


### PR DESCRIPTION
sizeof(pbb_header_t) was not 18 on my platform.
