### PR TITLE
Add support for ruby 2.1

### DIFF
--- a/ruby/trema/action-common.c
+++ b/ruby/trema/action-common.c
@@ -33,7 +33,7 @@ dl_addr_to_a( VALUE dl_addr, uint8_t *ret_dl_addr ) {
   int i;
 
   for ( i = 0; i < RARRAY_LEN( mac_arr ); i++ ) {
-    ret_dl_addr[ i ] = ( uint8_t ) ( NUM2INT( RARRAY_PTR( mac_arr )[ i ] ) );
+    ret_dl_addr[ i ] = ( uint8_t ) ( NUM2INT( rb_ary_entry( mac_arr,  i ) ) );
   }
   return ret_dl_addr;
 }
@@ -59,14 +59,12 @@ pack_basic_action( VALUE r_action ) {
   if ( !NIL_P( r_action ) ) {
     switch ( TYPE( r_action ) ) {
       case T_ARRAY: {
-          VALUE *each = RARRAY_PTR( r_action );
-
           r_action_ins = Data_Wrap_Struct( rb_obj_class( r_action ), NULL, NULL, actions );
 
           for ( int i = 0; i < RARRAY_LEN( r_action ); i++ ) {
-            if ( rb_respond_to( each[ i ], r_id ) ) {
-              r_action_ins = Data_Wrap_Struct( rb_obj_class( each[ i ] ), NULL, NULL, actions );
-              rb_funcall( each[ i ], r_id, 1, r_action_ins );
+            if ( rb_respond_to( rb_ary_entry( r_action, i ), r_id ) ) {
+              r_action_ins = Data_Wrap_Struct( rb_obj_class( rb_ary_entry( r_action, i ) ), NULL, NULL, actions );
+              rb_funcall( rb_ary_entry( r_action, i ), r_id, 1, r_action_ins );
             }
           }
       }
@@ -96,12 +94,10 @@ pack_flexible_action( VALUE r_action ) {
   if ( !NIL_P( r_action ) ) {
     switch ( TYPE( r_action ) ) {
       case T_ARRAY: {
-          VALUE *each = RARRAY_PTR( r_action );
-
           for ( int i = 0; i < RARRAY_LEN( r_action ); i++ ) {
-            if ( rb_respond_to( each[ i ], r_id ) ) {
-              r_oxm_ins = Data_Wrap_Struct( rb_obj_class( each[ i ] ), NULL, NULL, oxm_match );
-              rb_funcall( each[ i ], r_id, 1, r_oxm_ins );
+            if ( rb_respond_to( rb_ary_entry( r_action, i ), r_id ) ) {
+              r_oxm_ins = Data_Wrap_Struct( rb_obj_class( rb_ary_entry( r_action, i ) ), NULL, NULL, oxm_match );
+              rb_funcall( rb_ary_entry( r_action, i ), r_id, 1, r_oxm_ins );
             }
           }
       }
@@ -131,12 +127,10 @@ pack_instruction( VALUE r_instruction ) {
   if ( !NIL_P( r_instruction ) ) {
     switch ( TYPE( r_instruction ) ) {
       case T_ARRAY: {
-        VALUE *each = RARRAY_PTR( r_instruction );
-
         for ( int i = 0; i < RARRAY_LEN( r_instruction ); i++ ) {
-          if ( rb_respond_to( each[ i ], r_id ) ) {
-            r_ins_instance = Data_Wrap_Struct( rb_obj_class( each[ i ] ), NULL, NULL, instructions );
-            rb_funcall( each[ i ], r_id, 1, r_ins_instance );
+          if ( rb_respond_to( rb_ary_entry( r_instruction, i ), r_id ) ) {
+            r_ins_instance = Data_Wrap_Struct( rb_obj_class( rb_ary_entry( r_instruction, i ) ), NULL, NULL, instructions );
+            rb_funcall( rb_ary_entry( r_instruction, i ), r_id, 1, r_ins_instance );
           }
         }
       }

--- a/ruby/trema/basic-action.c
+++ b/ruby/trema/basic-action.c
@@ -165,7 +165,7 @@ pack_experimenter( VALUE self, VALUE actions, VALUE options ) {
     buffer *body = alloc_buffer_with_length( length );
     void *p = append_back_buffer( body, length );
     for ( int i = 0; i < length; i++ ) {
-      ( ( uint8_t * ) p )[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( r_body )[ i ] );
+      ( ( uint8_t * ) p )[ i ] = ( uint8_t ) FIX2INT( rb_ary_entry( r_body, i ) );
     }
     append_action_experimenter( openflow_actions_ptr( actions ), NUM2UINT( r_experimenter ), body );
     free_buffer( body );

--- a/ruby/trema/bucket-helper.c
+++ b/ruby/trema/bucket-helper.c
@@ -57,10 +57,8 @@ pack_buckets( VALUE r_bucket ) {
   if ( !NIL_P( r_bucket ) ) {
     switch ( TYPE( r_bucket ) ) {
       case T_ARRAY: {
-        VALUE *each = RARRAY_PTR( r_bucket );
-
         for ( int i = 0; i < RARRAY_LEN( r_bucket ); i++ ) {
-          pack_bucket( each[ i ], buckets );
+          pack_bucket( rb_ary_entry( r_bucket, i ), buckets );
         }
       }
       break;

--- a/ruby/trema/conversion-util.c
+++ b/ruby/trema/conversion-util.c
@@ -36,7 +36,7 @@ r_array_to_buffer( VALUE r_array ) {
     append_back_buffer( data, length );
     uint8_t *data_ptr = data->data;
     for ( uint32_t i = 0; i < length; i++ ) {
-      data_ptr[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( r_array ) [ i ] );
+      data_ptr[ i ] = ( uint8_t ) FIX2INT( rb_ary_entry( r_array , i ) );
     }
   }
   return data;

--- a/ruby/trema/instructions.c
+++ b/ruby/trema/instructions.c
@@ -101,7 +101,7 @@ pack_experimenter_instruction( VALUE self, VALUE r_instructions, VALUE r_options
     buffer *user_data = alloc_buffer_with_length( length );
     void *p = append_back_buffer( user_data, length );
     for ( int i = 0; i < length; i++ ) {
-      ( ( uint8_t * ) p )[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( r_user_data )[ i ] );
+      ( ( uint8_t * ) p )[ i ] = ( uint8_t ) FIX2INT( rb_ary_entry( r_user_data , i ) );
     }
     append_instructions_experimenter( instructions_ptr( r_instructions ), NUM2UINT( r_experimenter ), user_data );
     free_buffer( user_data );

--- a/ruby/trema/message-helper.c
+++ b/ruby/trema/message-helper.c
@@ -49,11 +49,9 @@ send_controller_message( VALUE self, VALUE datapath_id, VALUE message ) {
   if ( !NIL_P( message ) ) {
     switch ( TYPE( message ) ) {
       case T_ARRAY: {
-          VALUE *each = RARRAY_PTR( message );
-          
           for ( int i = 0; i < RARRAY_LEN( message ); i++ ) {
-            if ( rb_respond_to( each[ i ], id_pack_msg ) ) {
-              rb_funcall( each[ i ], id_pack_msg, 1, datapath_id );
+            if ( rb_respond_to( rb_ary_entry( message, i ), id_pack_msg ) ) {
+              rb_funcall( rb_ary_entry( message, i ), id_pack_msg, 1, datapath_id );
             }
           }
       }

--- a/ruby/trema/messages/echo-request.c
+++ b/ruby/trema/messages/echo-request.c
@@ -41,7 +41,7 @@ pack_echo_request( VALUE options ) {
 
         
         for ( int i = 0; i < buffer_len && i < RARRAY_LEN( r_body ); i++ ) {
-          buf[ i ]= ( uint8_t ) FIX2INT( RARRAY_PTR( r_body )[ i ] );
+          buf[ i ]= ( uint8_t ) FIX2INT( rb_ary_entry( r_body , i ) );
         }
     }
     else {

--- a/ruby/trema/messages/experimenter-multipart-request.c
+++ b/ruby/trema/messages/experimenter-multipart-request.c
@@ -59,7 +59,7 @@ pack_experimenter_multipart_request( VALUE options ) {
 
         
       for ( int i = 0; i < buffer_len && i < RARRAY_LEN( r_body ); i++ ) {
-        buf[ i ]= ( uint8_t ) FIX2INT( RARRAY_PTR( r_body )[ i ] );
+        buf[ i ]= ( uint8_t ) FIX2INT( rb_ary_entry( r_body , i ) );
       }
     }
     else {

--- a/ruby/trema/messages/hello.c
+++ b/ruby/trema/messages/hello.c
@@ -37,7 +37,7 @@ pack_hello( VALUE options ) {
         rb_raise(rb_eArgError, "Currently only a single version is supported" );
       }
       else {
-        ofp_version[ 0 ] = ( uint8_t ) NUM2UINT( RARRAY_PTR( r_version )[ 0 ] );
+        ofp_version[ 0 ] = ( uint8_t ) NUM2UINT( rb_ary_entry( r_version , 0 ) );
       }
     }
   }


### PR DESCRIPTION
Since PARRAY_PTR macro has been changed in Ruby 2.1, we need to use C-APIs instead.
