### PR TITLE
rewrite double linked list and hash table functions

### DIFF
--- a/src/lib/buffer.c
+++ b/src/lib/buffer.c
@@ -133,7 +133,7 @@ buffer *
 alloc_buffer_with_length( size_t length ) {
   assert( length != 0 );
 
-  private_buffer *new_buf = xcalloc( 1, sizeof( private_buffer ) );
+  private_buffer *new_buf = xmalloc( sizeof( private_buffer ) );
   new_buf->public.data = xmalloc( length );
   new_buf->public.length = 0;
   new_buf->public.user_data = NULL;

--- a/src/lib/doubly_linked_list.h
+++ b/src/lib/doubly_linked_list.h
@@ -32,19 +32,20 @@
  *
  * @code
  * // Create a doubly linked list ("alpha" <=> "bravo" <=> "charlie")
- * dlist_element *alpha = create_dlist();
+ * dlist_element *sentinel = create_dlist();
+ * dlist_element *alpha = insert_after_dlist( sentinel, "alpha" );
  * dlist_element *bravo = insert_after_dlist( alpha, "bravo" );
  * dlist_element *charlie = insert_after_dlist( bravo, "charlie" );
  *
  * // Find element "charlie" from the list
- * find_element( alpha, "charlie" ); // => charlie
- * find_element( alpha, "delta" ); // => NULL
+ * find_element( sentinel, "charlie" ); // => charlie
+ * find_element( sentinel, "delta" ); // => NULL
  *
  * // Delete element "bravo" from the list
- * delete_dlist_element( bravo ); // => true
+ * delete_dlist_element( sentinel, bravo ); // => true
  *
  * // Delete entire list
- * delete_dlist( alpha );
+ * delete_dlist( sentinel );
  * @endcode
  */
 
@@ -68,13 +69,13 @@ typedef struct dlist_element {
 
 
 dlist_element *create_dlist( void );
-dlist_element *insert_before_dlist( dlist_element *element, void *data );
-dlist_element *insert_after_dlist( dlist_element *element, void *data );
-dlist_element *get_first_element( dlist_element *element );
-dlist_element *get_last_element( dlist_element *element );
-dlist_element *find_element( dlist_element *element, const void *data );
-bool delete_dlist_element( dlist_element *element );
-bool delete_dlist( dlist_element *element );
+dlist_element *insert_before_dlist( dlist_element *sentinel, dlist_element *element, void *data );
+dlist_element *insert_after_dlist( dlist_element *sentinel, dlist_element *element, void *data );
+dlist_element *get_first_element( dlist_element *sentinel );
+dlist_element *get_last_element( dlist_element *sentinel );
+dlist_element *find_element( dlist_element *sentinel, const void *data );
+bool delete_dlist_element( dlist_element *sentinel, dlist_element *element );
+bool delete_dlist( dlist_element *sentinel );
 
 
 #endif // DOUBLY_LINKED_LIST_H

--- a/src/lib/hash_table.h
+++ b/src/lib/hash_table.h
@@ -90,12 +90,11 @@ typedef struct {
  * hash_table. It should only be accessed via the following functions.
  */
 typedef struct {
+  dlist_element **buckets;
   unsigned int number_of_buckets;
   compare_function compare;
   hash_function hash;
   unsigned int length;
-  dlist_element **buckets;
-  dlist_element *nonempty_bucket_index;
 } hash_table;
 
 
@@ -106,10 +105,9 @@ typedef struct {
  * initialized with init_hash_iterator().
  */
 typedef struct {
-  dlist_element **buckets;
-  dlist_element *bucket_index;
-  dlist_element *next_bucket_index;
-  dlist_element *element;
+  void **hash_entries;
+  unsigned int pos;
+  unsigned int length;
 } hash_iterator;
 
 

--- a/src/switch/datapath/action.c
+++ b/src/switch/datapath/action.c
@@ -223,12 +223,14 @@ void
 delete_action_list( action_list *list ) {
   assert( list != NULL );
 
-  for ( dlist_element *element = get_first_element( list ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     action *action = element->data;
     if ( action != NULL ) {
       delete_action( action );
     }
   }
+
   delete_dlist( list );
 }
 
@@ -261,7 +263,7 @@ append_action( action_list *list, action *action ) {
       return ERROR_OFDPE_BAD_ACTION_BAD_TYPE;
   }
 
-  list = insert_before_dlist( list, ( void * ) action );
+  list = insert_before_dlist( list, list, ( void * ) action );
   if ( list == NULL ) {
     return ERROR_APPEND_TO_LIST;
   }
@@ -274,13 +276,13 @@ OFDPE
 remove_action( action_list *list, action *action ) {
   assert( list != NULL );
   assert( action != NULL );
-  
+
   dlist_element *element = find_element( get_first_element( list ), action );
   if ( element == NULL ) {
     return ERROR_NOT_FOUND;
   }
   delete_action( action );
-  delete_dlist_element( element );
+  delete_dlist_element( list, element );
 
   return OFDPE_SUCCESS;
 }
@@ -307,11 +309,12 @@ duplicate_action_list( action_list *list ) {
   }
 
   dlist_element *dst = create_action_list();
-  for ( dlist_element *element = get_first_element( list ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     action *src_action = element->data;
     if ( src_action != NULL ) {
       action *dst_action = duplicate_action( src_action );
-      insert_before_dlist( dst, dst_action );
+      insert_before_dlist( dst, dst, dst_action );
     }
   }
 
@@ -336,7 +339,8 @@ validate_action_set( action_list *list ) {
   bool output = false;
 
   bool ret = true;
-  for ( dlist_element *element = get_first_element( list ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     action *action = element->data;
     if ( action == NULL ) {
       continue;
@@ -474,7 +478,8 @@ validate_action_list( action_list *list ) {
   }
 
   OFDPE ret = OFDPE_SUCCESS;
-  for ( dlist_element *element = get_first_element( list ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     if ( element->data == NULL ) {
       continue;
     }
@@ -536,7 +541,8 @@ write_action_set( action_list *list, action_set *set ) {
   assert( set != NULL );
 
   OFDPE ret = OFDPE_SUCCESS;
-  for ( dlist_element *element = get_first_element( list ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     if ( element->data == NULL ) {
       continue;
     }
@@ -821,7 +827,8 @@ void
 dump_action_list( action_list *list, void dump_function( const char *format, ... ) ) {
   assert( dump_function != NULL );
 
-  for ( dlist_element *e = get_first_element( list ); e != NULL; e = e->next ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
     if ( e->data == NULL ) {
       continue;
     }

--- a/src/switch/datapath/action_bucket.c
+++ b/src/switch/datapath/action_bucket.c
@@ -55,14 +55,14 @@ void
 delete_action_bucket_list( bucket_list *list ) {
   assert( list != NULL );
 
-  dlist_element *element = get_first_element( list );
-  while ( element != NULL ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     bucket *b = element->data;
     if ( b != NULL ) {
       delete_action_bucket( b );
     }
-    element = element->next;
   }
+
   delete_dlist( list );
 }
 
@@ -72,7 +72,7 @@ append_action_bucket( bucket_list *list, bucket *bucket ) {
   assert( list != NULL );
   assert( bucket != NULL );
 
-  list = insert_before_dlist( list, ( void * ) bucket );
+  list = insert_before_dlist( list, list, ( void * ) bucket );
   if ( list == NULL ) {
     return ERROR_NO_MEMORY;
   }
@@ -91,7 +91,7 @@ remove_action_bucket( bucket_list *list, bucket *bucket ) {
     return ERROR_NOT_FOUND;
   }
   delete_action_bucket( bucket );
-  delete_dlist_element( elemenet );
+  delete_dlist_element( list, elemenet );
 
   return OFDPE_SUCCESS;
 }
@@ -110,8 +110,9 @@ validate_action_bucket_list( bucket_list *buckets ) {
   assert( buckets != NULL );
 
   OFDPE ret = OFDPE_SUCCESS;
-  dlist_element *element = get_first_element( buckets );
-  while ( element != NULL ) {
+
+  dlist_element *sentinel = buckets;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     bucket *b = element->data;
     if ( b != NULL ) {
       ret = validate_action_bucket( b );
@@ -119,7 +120,6 @@ validate_action_bucket_list( bucket_list *buckets ) {
         break;
       }
     }
-    element = element->next;
   }
 
   return ret;
@@ -132,12 +132,11 @@ get_bucket_count( bucket_list *list ) {
 
   uint32_t count = 0;
 
-  dlist_element *element = get_first_element ( list );
-  while ( element != NULL ) {
+  dlist_element *sentinel = list;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     if ( element->data != NULL ) {
       count++;
     }
-    element = element->next;
   }
 
   return count;
@@ -165,7 +164,8 @@ duplicate_bucket_list( bucket_list *buckets ) {
   }
 
   bucket_list *duplicated = create_action_bucket_list();
-  for ( dlist_element *e = get_first_element( buckets ); e != NULL; e = e->next ) {
+  dlist_element *sentinel = buckets;
+  for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
     if ( e->data == NULL ) {
       continue;
     }
@@ -198,7 +198,8 @@ dump_buckets( bucket_list *buckets, void dump_function( const char *format, ... 
   assert( buckets != NULL );
   assert( dump_function != NULL );
 
-  for ( dlist_element *element = get_first_element( buckets ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = buckets;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     if ( element->data == NULL ) {
       continue;
     }

--- a/src/switch/datapath/flow_entry.c
+++ b/src/switch/datapath/flow_entry.c
@@ -60,7 +60,8 @@ alloc_flow_entry( match *match, instruction_set *instructions,
 
   if ( instructions->write_actions != NULL && instructions->write_actions->actions != NULL ) {
     action_list *actions = instructions->write_actions->actions;
-    for ( dlist_element *e = get_first_element( actions ); e != NULL; e = e->next ) {
+    dlist_element *sentinel = actions;
+    for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
       action *action = e->data;
       if ( action != NULL ) {
         action->entry = entry;
@@ -69,7 +70,8 @@ alloc_flow_entry( match *match, instruction_set *instructions,
   }
   if ( instructions->apply_actions != NULL && instructions->apply_actions->actions != NULL ) {
     action_list *actions = instructions->apply_actions->actions;
-    for ( dlist_element *e = get_first_element( actions ); e != NULL; e = e->next ) {
+    dlist_element *sentinel = actions;
+    for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
       action *action = e->data;
       if ( action != NULL ) {
         action->entry = entry;

--- a/src/switch/datapath/group_table.c
+++ b/src/switch/datapath/group_table.c
@@ -114,7 +114,8 @@ validate_buckets( uint8_t type, bucket_list *buckets ) {
   assert( buckets != NULL );
 
   OFDPE ret = OFDPE_SUCCESS;
-  for ( dlist_element *element = get_first_element( buckets ); element != NULL; element = element->next ) {
+  dlist_element *sentinel = buckets;
+  for ( dlist_element *element = sentinel->next; element != sentinel; element = element->next ) {
     if ( element->data == NULL ) {
       continue;
     }
@@ -337,7 +338,9 @@ get_group_stats( const uint32_t group_id, group_stats **stats, uint32_t *n_group
     stat->duration_sec = ( uint32_t ) diff.tv_sec;
     stat->duration_nsec = ( uint32_t ) diff.tv_nsec;
     create_list( &stat->bucket_stats );
-    for ( dlist_element *b = get_first_element( entry->buckets ); b != NULL; b = b->next ) {
+
+    dlist_element *sentinel = entry->buckets;
+    for ( dlist_element *b = sentinel->next; b != sentinel; b = b->next ) {
       if ( b->data == NULL ) {
         continue;
       }

--- a/src/switch/datapath/instruction.c
+++ b/src/switch/datapath/instruction.c
@@ -104,6 +104,7 @@ free_instruction( instruction *instruction ) {
 
   if ( instruction->actions != NULL ) {
     delete_action_list( instruction->actions );
+    instruction->actions = NULL;
   }
 
   xfree( instruction );
@@ -525,7 +526,8 @@ update_reference_counters_in_instruction( instruction *instruction, counter_upda
     return;
   }
 
-  for ( dlist_element *a = get_first_element( instruction->actions ); a != NULL; a = a->next ) {
+  dlist_element *sentinel = instruction->actions;
+  for ( dlist_element *a = sentinel->next; a != sentinel; a = a->next ) {
     if ( a->data == NULL ) {
       continue;
     }

--- a/src/switch/datapath/openflow_helper.c
+++ b/src/switch/datapath/openflow_helper.c
@@ -469,7 +469,8 @@ get_ofp_bucket_length( const bucket *bucket ) {
   size_t length = offsetof( struct ofp_bucket, actions );
 
   if ( bucket->actions != NULL ) {
-    for ( dlist_element *e = get_first_element( bucket->actions ); e != NULL; e = e->next ) {
+    dlist_element *sentinel = bucket->actions;
+    for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
       if ( e->data == NULL ) {
         continue;
       }
@@ -487,7 +488,8 @@ get_ofp_buckets_length( bucket_list *buckets ) {
 
   size_t length = 0;
 
-  for ( dlist_element *e = get_first_element( buckets ); e != NULL; e = e->next ) {
+  dlist_element *sentinel = buckets;
+  for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
     if ( e->data == NULL ) {
       continue;
     }
@@ -628,7 +630,8 @@ get_ofp_bucket( const bucket *bucket, struct ofp_bucket **translated, size_t *le
 
   bool ret = true;
   struct ofp_action_header *actions = ( *translated )->actions;
-  for ( dlist_element *e = get_first_element( bucket->actions ); e != NULL; e = e->next ) {
+  dlist_element *sentinel = bucket->actions;
+  for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
     if ( e->data == NULL ) {
       continue;
     }

--- a/src/switch/switch/action-helper.c
+++ b/src/switch/switch/action-helper.c
@@ -124,16 +124,15 @@ _action_pack( void *dest, action_list **list  ) {
   if ( *list == NULL ) {
     return;
   }
-  dlist_element *item = get_first_element( *list );
-  action *action;
   struct ofp_action_header *ac_hdr = dest;
-  while ( item != NULL ) {
-    action = item->data;
+
+  dlist_element *sentinel = *list;
+  for ( dlist_element *item = sentinel->next; item != sentinel; item = item->next ) {
+    action *action = item->data;
     if ( action != NULL ) {
       action_tlv_pack( ac_hdr, action );
       ac_hdr = ( struct ofp_action_header * ) ( ( char * ) ac_hdr + ac_hdr->len );
     }
-    item = item->next;
   }
 }
 void ( *action_pack )( void *dest, action_list **list ) = _action_pack;
@@ -145,10 +144,9 @@ _action_list_length( action_list **list ) {
     return 0;
   }
   uint16_t length = 0;
-  dlist_element *item = get_first_element( *list );
-  action *action;
-  while ( item != NULL ) {
-    action = item->data;
+  dlist_element *sentinel = *list;
+  for ( dlist_element *item = sentinel->next; item != sentinel; item = item->next ) {
+    action *action = item->data;
     if ( action != NULL ) {
       length = ( uint16_t ) ( length + action_tlv_length_by_type( action->type ) );
       if ( action->type == OFPAT_SET_FIELD && action->match ) {
@@ -158,7 +156,6 @@ _action_list_length( action_list **list ) {
         length = ( uint16_t ) ( length + PADLEN_TO_64( length ) );
       }
     }
-    item = item->next;
   }
   return length;
 }

--- a/unittests/lib/doubly_linked_list_test.c
+++ b/unittests/lib/doubly_linked_list_test.c
@@ -68,8 +68,8 @@ test_create_dlist() {
 
   assert_true( new_element != NULL );
   assert_true( new_element->data == NULL );
-  assert_true( new_element->next == NULL );
-  assert_true( new_element->prev == NULL );
+  assert_true( new_element->next == new_element );
+  assert_true( new_element->prev == new_element );
 
   delete_dlist( new_element );
 }
@@ -194,61 +194,67 @@ test_get_last_element_aborts_with_NULL_dlist() {
 // Remove "alpha" of "alpha" <-> "bravo" <-> "charlie"
 static void
 test_remove_first_element() {
+  char element_data1[] = "alpha";
   char element_data2[] = "bravo";
   char element_data3[] = "charlie";
 
-  dlist_element *alpha = create_dlist();
+  dlist_element *sentinel = create_dlist();
+  dlist_element *alpha = insert_after_dlist( sentinel, element_data1 );
   dlist_element *bravo = insert_after_dlist( alpha, element_data2 );
   dlist_element *charlie = insert_after_dlist( bravo, element_data3 );
 
-  assert_true( delete_dlist_element( alpha ) );
-  assert_true( bravo->prev == NULL );
+  assert_true( delete_dlist_element( sentinel, alpha ) );
+  assert_true( bravo->prev == sentinel );
   assert_true( bravo->next == charlie );
 
-  delete_dlist( bravo );
+  delete_dlist( sentinel );
 }
 
 
 // Remove "bravo" of "alpha" <-> "bravo" <-> "charlie"
 static void
 test_remove_middle_element() {
+  char element_data1[] = "alpha";
   char element_data2[] = "bravo";
   char element_data3[] = "charlie";
 
-  dlist_element *alpha = create_dlist();
+  dlist_element *sentinel = create_dlist();
+  dlist_element *alpha = insert_after_dlist( sentinel, element_data1 );
   dlist_element *bravo = insert_after_dlist( alpha, element_data2 );
   dlist_element *charlie = insert_after_dlist( bravo, element_data3 );
 
-  assert_true( delete_dlist_element( bravo ) );
+  assert_true( delete_dlist_element( sentinel, bravo ) );
   assert_true( alpha->next == charlie );
   assert_true( charlie->prev == alpha );
 
-  delete_dlist( alpha );
+  delete_dlist( sentinel );
 }
 
 
 // Remove "charlie" of "alpha" <-> "bravo" <-> "charlie"
 static void
 test_remove_last_element() {
+  char element_data1[] = "alpha";
   char element_data2[] = "bravo";
   char element_data3[] = "charlie";
 
-  dlist_element *alpha = create_dlist();
+  dlist_element *sentinel = create_dlist();
+  dlist_element *alpha = insert_after_dlist( sentinel, element_data1 );
   dlist_element *bravo = insert_after_dlist( alpha, element_data2 );
   dlist_element *charlie = insert_after_dlist( bravo, element_data3 );
 
-  assert_true( delete_dlist_element( charlie ) );
-  assert_true( bravo->next == NULL );
+  assert_true( delete_dlist_element( sentinel, charlie ) );
+  assert_true( bravo->next == sentinel );
   assert_true( bravo->prev == alpha );
 
-  delete_dlist( alpha );
+  delete_dlist( sentinel );
 }
 
 
 static void
 test_delete_dlist_element_aborts_with_NULL_dlist() {
   expect_string( mock_die, output, "element must not be NULL" );
-  expect_assert_failure( delete_dlist_element( NULL ) );
+  expect_assert_failure( delete_dlist_element( NULL, NULL ) );
 }
 
 

--- a/unittests/lib/timer_test.c
+++ b/unittests/lib/timer_test.c
@@ -80,12 +80,9 @@ mock_debug( const char *format, ... ) {
 
 static timer_callback_info *
 find_timer_callback( void ( *callback )( void *user_data ) ) {
-  dlist_element *e;
-  timer_callback_info *cb;
-
-  cb = NULL;
-  for ( e = timer_callbacks->next; e; e = e->next ) {
-    cb = e->data;
+  dlist_element *sentinel = timer_callbacks;
+  for ( dlist_element *e = sentinel->next; e != sentinel; e = e->next ) {
+    timer_callback_info * cb = e->data;
     if ( cb->function == callback ) {
       return cb;
     }

--- a/unittests/switch/switch/stats-helper-test.c
+++ b/unittests/switch/switch/stats-helper-test.c
@@ -985,7 +985,7 @@ test_instructions( void **state ) {
   if ( e->data == NULL ) {
     e = ins_list->next;
   }
-  for (; e; e = e->next ) {
+  for (; e != ins_list; e = e->next ) {
     if ( e->data != NULL ) {
       instruction *ins = e->data;
       printf( "ins type( %u )\n", ins->type );
@@ -999,7 +999,7 @@ test_instructions( void **state ) {
   if ( e->data == NULL ) {
     e = ins_list->next;
   }
-  for (; e; e = e->next ) {
+  for (; e != ins_list; e = e->next ) {
     if ( e->data != NULL ) {
       instruction *ins = e->data;
       printf( "ad ins type( %u )\n", ins->type );
@@ -1011,7 +1011,7 @@ test_instructions( void **state ) {
   if ( e->data == NULL ) {
     e = new_ins_list->next;
   }
-  for (; e; e = e->next ) {
+  for (; e != new_ins_list; e = e->next ) {
     if ( e->data != NULL ) {
       instruction *ins = e->data;
       printf( "ins type( %u )\n", ins->type );


### PR DESCRIPTION
Double linked list now uses a sentinel as a handler.
If prev or next hits the sentinel, then those are the ends.
The reason of using sentinel is that sentinel has a mutex
internally, and could not be NULL.
One more merit of using sentinel is performance improvement
in scanning the elements from the last to first.

Hash table data structure became simple.

Memory usage was reduced.
