### PR TITLE
Change variable arp_op to arp_opcode to avoid name collision with netinet/ether.h

### DIFF
--- a/ruby/trema/conversion-util.c
+++ b/ruby/trema/conversion-util.c
@@ -253,7 +253,7 @@ r_match_to_oxm_match( VALUE r_match, oxm_matches *match ) {
   APPEND_OXM_MATCH_UINT8( r_match, "@icmpv4_type", append_oxm_match_icmpv4_type, match );
   APPEND_OXM_MATCH_UINT8( r_match, "@icmpv4_code", append_oxm_match_icmpv4_code, match );
 
-  APPEND_OXM_MATCH_UINT16( r_match, "@arp_op", append_oxm_match_arp_op, match );
+  APPEND_OXM_MATCH_UINT16( r_match, "@arp_opcode", append_oxm_match_arp_opcode, match );
 
   APPEND_OXM_MATCH_IPV4_ADDR_MASK( r_match, "@arp_spa", append_oxm_match_arp_spa, match );
   APPEND_OXM_MATCH_IPV4_ADDR_MASK( r_match, "@arp_tpa", append_oxm_match_arp_tpa, match );

--- a/ruby/trema/flexible-action.c
+++ b/ruby/trema/flexible-action.c
@@ -345,12 +345,12 @@ pack_icmpv4_code( VALUE self, VALUE actions, VALUE options ) {
 
 static VALUE
 pack_arp_op( VALUE self, VALUE actions, VALUE options ) {
-  VALUE r_arp_op = HASH_REF( options, arp_op );
+  VALUE r_arp_op = HASH_REF( options, arp_opcode );
   if ( rb_obj_is_kind_of( actions, basic_action_eval ) ) {
     append_action_set_field_arp_op( openflow_actions_ptr( actions ), ( const uint16_t ) NUM2UINT( r_arp_op ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_arp_op( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_arp_op ) );
+    append_oxm_match_arp_opcode( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_arp_op ) );
   }
 
   return self;

--- a/src/lib/openflow_message.c
+++ b/src/lib/openflow_message.c
@@ -3192,14 +3192,14 @@ append_action_set_field_icmpv4_code( openflow_actions *actions, const uint8_t ic
 
 
 bool
-append_action_set_field_arp_op( openflow_actions *actions, const uint16_t arp_op ) {
+append_action_set_field_arp_op( openflow_actions *actions, const uint16_t arp_opcode ) {
   bool ret;
 
-  debug( "Appending a set field arp op action ( arp_op = %#x ).", arp_op );
+  debug( "Appending a set field arp op action ( arp_op = %#x ).", arp_opcode );
 
   assert( actions != NULL );
 
-  ret = append_action_set_field( actions, OXM_OF_ARP_OP, &arp_op );
+  ret = append_action_set_field( actions, OXM_OF_ARP_OP, &arp_opcode );
 
   return ret;
 }
@@ -8427,7 +8427,7 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
   }
   else if ( eth_type == ETH_ETHTYPE_ARP ) {
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_OP ) ) ) {
-      append_oxm_match_arp_op( match, ( ( packet_info * ) packet->user_data )->arp_ar_op );
+      append_oxm_match_arp_opcode( match, ( ( packet_info * ) packet->user_data )->arp_ar_op );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_SPA ) ) ) {
       append_oxm_match_arp_spa( match, ( ( packet_info * ) packet->user_data )->arp_spa, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_arp_spa ) );

--- a/src/lib/openflow_message.h
+++ b/src/lib/openflow_message.h
@@ -261,7 +261,7 @@ bool append_action_set_field_sctp_src( openflow_actions *actions, const uint16_t
 bool append_action_set_field_sctp_dst( openflow_actions *actions, const uint16_t sctp_dst );
 bool append_action_set_field_icmpv4_type( openflow_actions *actions, const uint8_t icmpv4_type );
 bool append_action_set_field_icmpv4_code( openflow_actions *actions, const uint8_t icmpv4_code );
-bool append_action_set_field_arp_op( openflow_actions *actions, const uint16_t arp_op );
+bool append_action_set_field_arp_op( openflow_actions *actions, const uint16_t arp_opcode );
 bool append_action_set_field_arp_spa( openflow_actions *actions, const uint32_t arp_spa );
 bool append_action_set_field_arp_tpa( openflow_actions *actions, const uint32_t arp_tpa );
 bool append_action_set_field_arp_sha( openflow_actions *actions, const uint8_t arp_sha[ OFP_ETH_ALEN ] );

--- a/src/lib/oxm_match.c
+++ b/src/lib/oxm_match.c
@@ -496,7 +496,7 @@ append_oxm_match_icmpv4_code( oxm_matches *matches, uint8_t code ) {
 
 
 bool
-append_oxm_match_arp_op( oxm_matches *matches, uint16_t value ) {
+append_oxm_match_arp_opcode( oxm_matches *matches, uint16_t value ) {
   assert( matches != NULL );
 
   return append_oxm_match_16( matches, OXM_OF_ARP_OP, value );  

--- a/src/lib/oxm_match.h
+++ b/src/lib/oxm_match.h
@@ -68,7 +68,7 @@ bool append_oxm_match_sctp_src( oxm_matches *matches, uint16_t port );
 bool append_oxm_match_sctp_dst( oxm_matches *matches, uint16_t port );
 bool append_oxm_match_icmpv4_type( oxm_matches *matches, uint8_t type );
 bool append_oxm_match_icmpv4_code( oxm_matches *matches, uint8_t code );
-bool append_oxm_match_arp_op( oxm_matches *matches, uint16_t value );
+bool append_oxm_match_arp_opcode( oxm_matches *matches, uint16_t value );
 bool append_oxm_match_arp_spa( oxm_matches *matches, uint32_t addr, uint32_t mask );
 bool append_oxm_match_arp_tpa( oxm_matches *matches, uint32_t addr, uint32_t mask );
 bool append_oxm_match_arp_sha( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] );

--- a/src/switch/datapath/action_executor.c
+++ b/src/switch/datapath/action_executor.c
@@ -1783,8 +1783,8 @@ execute_action_set_field( buffer *frame, action *set_field ) {
     }
   }
 
-  if ( match->arp_op.valid ) {
-    if ( !set_arp_op( frame, match->arp_op.value ) ) {
+  if ( match->arp_opcode.valid ) {
+    if ( !set_arp_op( frame, match->arp_opcode.value ) ) {
       return false;
     }
   }

--- a/src/switch/datapath/match.c
+++ b/src/switch/datapath/match.c
@@ -76,7 +76,7 @@ init_match( match *new_match ) {
 
   memset( new_match, 0, sizeof( match ) );
 
-  init_match16( &new_match->arp_op );
+  init_match16( &new_match->arp_opcode );
   for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
     init_match8( &( new_match->arp_sha[ i ] ) );
   }
@@ -216,7 +216,7 @@ validate_match( match *match ) {
     }
   }
 
-  if ( match->arp_op.valid || match->arp_spa.valid || match->arp_tpa.valid ||
+  if ( match->arp_opcode.valid || match->arp_spa.valid || match->arp_tpa.valid ||
        match->arp_sha[ 0 ].valid || match->arp_tha[ 0 ].valid ) {
     if ( !match->eth_type.valid || match->eth_type.value != ETH_ETHTYPE_ARP ) {
       return ERROR_OFDPE_BAD_MATCH_BAD_PREREQ;
@@ -323,7 +323,7 @@ compare_match_strict( const match *x, const match *y ) {
   assert( x != NULL );
   assert( y != NULL );
 
-  if ( !compare_match16_strict( x->arp_op, y->arp_op ) ) {
+  if ( !compare_match16_strict( x->arp_opcode, y->arp_opcode ) ) {
     return false;
   }
   for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
@@ -589,7 +589,7 @@ compare_match( const match *narrow, const match *wide ) {
   assert( narrow != NULL );
   assert( wide != NULL );
 
-  if ( !compare_match16( narrow->arp_op, wide->arp_op ) ) {
+  if ( !compare_match16( narrow->arp_opcode, wide->arp_opcode ) ) {
     return false;
   }
   for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
@@ -774,9 +774,9 @@ build_match_from_packet_info( match *m, const packet_info *pinfo ) {
   }
 
   if ( ( pinfo->format & NW_ARP ) != 0 ) {
-    m->arp_op.value = pinfo->arp_ar_op;
-    m->arp_op.mask = UINT16_MAX;
-    m->arp_op.valid = true;
+    m->arp_opcode.value = pinfo->arp_ar_op;
+    m->arp_opcode.mask = UINT16_MAX;
+    m->arp_opcode.valid = true;
     for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
       m->arp_sha[ i ].value = pinfo->arp_sha[ i ];
       m->arp_sha[ i ].mask = UINT8_MAX;
@@ -961,8 +961,8 @@ build_all_wildcarded_match( match *m ) {
   m->pbb_isid.mask = 0;
   m->pbb_isid.valid = true;
 
-  m->arp_op.mask = 0;
-  m->arp_op.valid = true;
+  m->arp_opcode.mask = 0;
+  m->arp_opcode.valid = true;
 
   for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
     m->arp_sha[ i ].mask = 0;
@@ -1186,7 +1186,7 @@ dump_match( const match *m, void dump_function( const char *format, ... ) ) {
   assert( m != NULL );
   assert( dump_function != NULL );
 
-  dump_match16( "arp_op", &m->arp_op, dump_function );
+  dump_match16( "arp_opcode", &m->arp_opcode, dump_function );
   dump_eth_addr( "arp_sha", m->arp_sha, dump_function );
   dump_match32( "arp_spa", &m->arp_spa, dump_function );
   dump_eth_addr( "arp_tha", m->arp_tha, dump_function );
@@ -1273,7 +1273,7 @@ merge_match( match *dst, const match *src) {
   assert( dst != NULL );
   assert( src != NULL );
 
-  merge_match16( &dst->arp_op, &src->arp_op );
+  merge_match16( &dst->arp_opcode, &src->arp_opcode );
   for ( int i = 0; i < ETH_ADDRLEN; i++ ) {
     merge_match8( &( dst->arp_sha[ i ] ), &( src->arp_sha[ i ] ) );
   }

--- a/src/switch/datapath/match.h
+++ b/src/switch/datapath/match.h
@@ -111,7 +111,7 @@ typedef struct {
 } match64;
 
 typedef struct {
-  match16 arp_op;
+  match16 arp_opcode;
   match8 arp_sha[ ETH_ADDRLEN ];
   match32 arp_spa;
   match8 arp_tha[ ETH_ADDRLEN ];

--- a/src/switch/datapath/openflow_helper.c
+++ b/src/switch/datapath/openflow_helper.c
@@ -293,7 +293,7 @@ get_oxm_length( const match *match ) {
 
   size_t length = 0;
 
-  length += get_oxm_length_from_match16( &match->arp_op, 1 );
+  length += get_oxm_length_from_match16( &match->arp_opcode, 1 );
   length += get_oxm_length_from_match8( match->arp_sha, ETH_ADDRLEN );
   length += get_oxm_length_from_match32( &match->arp_spa, 1 );
   length += get_oxm_length_from_match8( match->arp_tha, ETH_ADDRLEN );

--- a/src/switch/switch/oxm-arp-op.c
+++ b/src/switch/switch/oxm-arp-op.c
@@ -57,7 +57,7 @@ static uint16_t
 arp_op_length( const match *match ) {
   uint16_t length = 0;
   
-  if ( match->arp_op.valid ) {
+  if ( match->arp_opcode.valid ) {
     length = oxm_arp_op.length;
   }
   return length;
@@ -66,10 +66,10 @@ arp_op_length( const match *match ) {
 
 static uint16_t
 pack_arp_op( oxm_match_header *hdr, const match *match ) {
-  if ( match->arp_op.valid ) {
+  if ( match->arp_opcode.valid ) {
     *hdr = OXM_OF_ARP_OP; 
     uint16_t *value = ( uint16_t * ) ( ( char * ) hdr + sizeof ( oxm_match_header ) );
-    *value = match->arp_op.value;
+    *value = match->arp_opcode.value;
     return oxm_arp_op.length;
   }
   return 0;

--- a/src/switch/switch/oxm-helper.c
+++ b/src/switch/switch/oxm-helper.c
@@ -374,7 +374,7 @@ _assign_match( match *match, const oxm_match_header *hdr ) {
     break;
     case OXM_OF_ARP_OP: {
       const uint16_t *value = ( const uint16_t * ) ( ( const char * ) hdr + sizeof ( oxm_match_header ) );
-      MATCH_ATTR_SET( arp_op, *value )
+      MATCH_ATTR_SET( arp_opcode, *value )
     }
     break;
     case OXM_OF_ARP_SPA:
@@ -483,7 +483,7 @@ _construct_oxm( oxm_matches *oxm_match, match *match ) {
   APPEND_OXM_MATCH( vlan_pcp )
   APPEND_OXM_MATCH( icmpv4_type )
   APPEND_OXM_MATCH( icmpv6_type )
-  APPEND_OXM_MATCH( arp_op )
+  APPEND_OXM_MATCH( arp_opcode )
   uint8_t eth_addr[ ETH_ADDRLEN ];
   uint8_t eth_addr_mask[ ETH_ADDRLEN ];
   if ( match->arp_sha[ 0 ].valid ) {

--- a/unittests/lib/openflow_message_test.c
+++ b/unittests/lib/openflow_message_test.c
@@ -13023,7 +13023,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_tag_and_wildcards_is_zero
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_vlan_pcp( expected, packet_info0->vlan_prio );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13075,7 +13075,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_zero() {
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13127,7 +13127,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IN_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13180,7 +13180,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IN_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13233,7 +13233,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_META
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13285,7 +13285,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ETH_
     append_oxm_match_eth_src( expected, ether->macsa, mask.mask_eth_src );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13337,7 +13337,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ETH_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13433,7 +13433,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_VLAN
     append_oxm_match_eth_src( expected, ether->macsa, mask.mask_eth_src );
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13486,7 +13486,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_VLAN
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13539,7 +13539,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_D
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13592,7 +13592,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_E
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13645,7 +13645,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13698,7 +13698,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV4
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13751,7 +13751,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV4
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13804,7 +13804,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TCP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13857,7 +13857,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TCP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13910,7 +13910,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_UDP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13963,7 +13963,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_UDP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14016,7 +14016,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_SCTP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14069,7 +14069,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_SCTP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14122,7 +14122,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14175,7 +14175,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14280,7 +14280,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14332,7 +14332,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14384,7 +14384,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14436,7 +14436,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14488,7 +14488,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14541,7 +14541,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14594,7 +14594,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14647,7 +14647,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14700,7 +14700,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14753,7 +14753,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14806,7 +14806,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14859,7 +14859,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14912,7 +14912,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14965,7 +14965,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15018,7 +15018,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15071,7 +15071,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_PBB_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15124,7 +15124,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TUNN
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15177,7 +15177,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );

--- a/unittests/lib/oxm_match_test.c
+++ b/unittests/lib/oxm_match_test.c
@@ -1282,16 +1282,16 @@ test_append_oxm_match_icmpv4_code() {
 
 
 static void
-test_append_oxm_match_arp_op() {
+test_append_oxm_match_arp_opcode() {
   const oxm_match_header type = OXM_OF_ARP_OP;
   const uint16_t data = data_16bit;
   const uint16_t offset = sizeof( oxm_match_header );
 
   oxm_matches *matches = create_oxm_matches();
 
-  expect_assert_failure( append_oxm_match_arp_op( NULL, data ) );
+  expect_assert_failure( append_oxm_match_arp_opcode( NULL, data ) );
 
-  bool ret = append_oxm_match_arp_op( matches, data );
+  bool ret = append_oxm_match_arp_opcode( matches, data );
   assert_true( ret );
 
   oxm_match_header *chk_hdr;
@@ -2122,7 +2122,7 @@ test_parse_ofp_match() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_op( expected, data_16bit );
+    append_oxm_match_arp_opcode( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -2215,7 +2215,7 @@ test_construct_ofp_match() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_op( expected, data_16bit );
+    append_oxm_match_arp_opcode( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -2311,7 +2311,7 @@ test_duplicate_oxm_matches() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_op( expected, data_16bit );
+    append_oxm_match_arp_opcode( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -3095,9 +3095,9 @@ test_compare_oxm_match_with_arp_op() {
   y = create_oxm_matches();
   z = create_oxm_matches();
 
-  append_oxm_match_arp_op( x, 1 );
-  append_oxm_match_arp_op( y, 1 );
-  append_oxm_match_arp_op( z, 2 );
+  append_oxm_match_arp_opcode( x, 1 );
+  append_oxm_match_arp_opcode( y, 1 );
+  append_oxm_match_arp_opcode( z, 2 );
 
   assert_true( compare_oxm_match( x, y ) );
   assert_false( compare_oxm_match( x, z ) );
@@ -4655,9 +4655,9 @@ test_compare_oxm_match_strict_with_arp_op() {
   y = create_oxm_matches();
   z = create_oxm_matches();
 
-  append_oxm_match_arp_op( x, 1 );
-  append_oxm_match_arp_op( y, 1 );
-  append_oxm_match_arp_op( z, 2 );
+  append_oxm_match_arp_opcode( x, 1 );
+  append_oxm_match_arp_opcode( y, 1 );
+  append_oxm_match_arp_opcode( z, 2 );
 
   assert_true( compare_oxm_match_strict( x, y ) );
   assert_false( compare_oxm_match_strict( x, z ) );
@@ -5524,7 +5524,7 @@ main() {
     unit_test( test_append_oxm_match_sctp_dst ),
     unit_test( test_append_oxm_match_icmpv4_type ),
     unit_test( test_append_oxm_match_icmpv4_code ),
-    unit_test( test_append_oxm_match_arp_op ),
+    unit_test( test_append_oxm_match_arp_opcode ),
     unit_test( test_append_oxm_match_arp_spa ),
     unit_test( test_append_oxm_match_arp_tpa ),
     unit_test( test_append_oxm_match_arp_sha ),

--- a/unittests/lib/utility_test.c
+++ b/unittests/lib/utility_test.c
@@ -228,7 +228,7 @@ test_match_to_string() {
       "ipv4_src = 1.2.3.4, ipv4_src = 1.2.3.4/255.255.0.0, "
       "ipv4_dst = 1.2.3.4, ipv4_dst = 1.2.3.4/255.255.0.0, "
       "tcp_src = 1000, tcp_dst = 2000, udp_src = 3000, udp_dst = 4000, sctp_src = 5000, sctp_dst = 6000, "
-      "icmpv4_type = 0x07, icmpv4_code = 0x08, arp_op = 0x0102, "
+      "icmpv4_type = 0x07, icmpv4_code = 0x08, arp_opcode = 0x0102, "
       "arp_spa = 1.2.3.4, arp_spa = 1.2.3.4/255.255.0.0, "
       "arp_tpa = 1.2.3.4, arp_tpa = 1.2.3.4/255.255.0.0, "
       "arp_sha = 01:02:03:04:05:06, arp_sha = 01:02:03:04:05:06/ff:ff:ff:00:00:00, "
@@ -304,7 +304,7 @@ test_match_to_string() {
     append_oxm_match_sctp_dst( match, 6000 );
     append_oxm_match_icmpv4_type( match, 7 );
     append_oxm_match_icmpv4_code( match, 8 );
-    append_oxm_match_arp_op( match, data_16bit );
+    append_oxm_match_arp_opcode( match, data_16bit );
     append_oxm_match_arp_spa( match, data_32bit, nomask_32bit );
     append_oxm_match_arp_spa( match, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( match, data_32bit, nomask_32bit );


### PR DESCRIPTION
The detail problem description could be found [here on trema-dev](https://groups.google.com/forum/#!topic/trema-dev/YaZJYqUwOCw)

A test example could be found here:
[Makefile](https://gist.github.com/rascov/9949933)
[arp_opcode_test.c](https://gist.github.com/rascov/9949949)
After updating trema-edge to this version, we no longer need to #undef arp_op anymore while using netinet/ether.h
