### PR TITLE
Keep using the interface append_oxm_match_arp_op() and add an exception in oxm-helper.c

### DIFF
--- a/ruby/trema/conversion-util.c
+++ b/ruby/trema/conversion-util.c
@@ -253,7 +253,7 @@ r_match_to_oxm_match( VALUE r_match, oxm_matches *match ) {
   APPEND_OXM_MATCH_UINT8( r_match, "@icmpv4_type", append_oxm_match_icmpv4_type, match );
   APPEND_OXM_MATCH_UINT8( r_match, "@icmpv4_code", append_oxm_match_icmpv4_code, match );
 
-  APPEND_OXM_MATCH_UINT16( r_match, "@arp_opcode", append_oxm_match_arp_opcode, match );
+  APPEND_OXM_MATCH_UINT16( r_match, "@arp_op", append_oxm_match_arp_op, match );
 
   APPEND_OXM_MATCH_IPV4_ADDR_MASK( r_match, "@arp_spa", append_oxm_match_arp_spa, match );
   APPEND_OXM_MATCH_IPV4_ADDR_MASK( r_match, "@arp_tpa", append_oxm_match_arp_tpa, match );

--- a/ruby/trema/flexible-action.c
+++ b/ruby/trema/flexible-action.c
@@ -350,7 +350,7 @@ pack_arp_op( VALUE self, VALUE actions, VALUE options ) {
     append_action_set_field_arp_op( openflow_actions_ptr( actions ), ( const uint16_t ) NUM2UINT( r_arp_op ) );
   }
   else if ( rb_obj_is_kind_of( actions, flexible_action_eval ) ) {
-    append_oxm_match_arp_opcode( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_arp_op ) );
+    append_oxm_match_arp_op( oxm_match_ptr( actions ), ( uint16_t ) NUM2UINT( r_arp_op ) );
   }
 
   return self;

--- a/src/lib/openflow_message.c
+++ b/src/lib/openflow_message.c
@@ -8427,7 +8427,7 @@ set_match_from_packet( oxm_matches *match, const uint32_t in_port,
   }
   else if ( eth_type == ETH_ETHTYPE_ARP ) {
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_OP ) ) ) {
-      append_oxm_match_arp_opcode( match, ( ( packet_info * ) packet->user_data )->arp_ar_op );
+      append_oxm_match_arp_op( match, ( ( packet_info * ) packet->user_data )->arp_ar_op );
     }
     if ( no_mask || !( mask->wildcards & WILDCARD_OFB_BIT( OFPXMT_OFB_ARP_SPA ) ) ) {
       append_oxm_match_arp_spa( match, ( ( packet_info * ) packet->user_data )->arp_spa, ( uint32_t ) ( no_mask ? UINT32_MAX : mask->mask_arp_spa ) );

--- a/src/lib/oxm_match.c
+++ b/src/lib/oxm_match.c
@@ -496,7 +496,7 @@ append_oxm_match_icmpv4_code( oxm_matches *matches, uint8_t code ) {
 
 
 bool
-append_oxm_match_arp_opcode( oxm_matches *matches, uint16_t value ) {
+append_oxm_match_arp_op( oxm_matches *matches, uint16_t value ) {
   assert( matches != NULL );
 
   return append_oxm_match_16( matches, OXM_OF_ARP_OP, value );  

--- a/src/lib/oxm_match.h
+++ b/src/lib/oxm_match.h
@@ -68,7 +68,7 @@ bool append_oxm_match_sctp_src( oxm_matches *matches, uint16_t port );
 bool append_oxm_match_sctp_dst( oxm_matches *matches, uint16_t port );
 bool append_oxm_match_icmpv4_type( oxm_matches *matches, uint8_t type );
 bool append_oxm_match_icmpv4_code( oxm_matches *matches, uint8_t code );
-bool append_oxm_match_arp_opcode( oxm_matches *matches, uint16_t value );
+bool append_oxm_match_arp_op( oxm_matches *matches, uint16_t value );
 bool append_oxm_match_arp_spa( oxm_matches *matches, uint32_t addr, uint32_t mask );
 bool append_oxm_match_arp_tpa( oxm_matches *matches, uint32_t addr, uint32_t mask );
 bool append_oxm_match_arp_sha( oxm_matches *matches, uint8_t addr[ OFP_ETH_ALEN ], uint8_t mask[ OFP_ETH_ALEN ] );

--- a/src/switch/switch/oxm-helper.c
+++ b/src/switch/switch/oxm-helper.c
@@ -483,8 +483,10 @@ _construct_oxm( oxm_matches *oxm_match, match *match ) {
   APPEND_OXM_MATCH( vlan_pcp )
   APPEND_OXM_MATCH( icmpv4_type )
   APPEND_OXM_MATCH( icmpv6_type )
-  APPEND_OXM_MATCH( arp_opcode )
-  uint8_t eth_addr[ ETH_ADDRLEN ];
+  if ( match->arp_opcode.valid ) {
+		append_oxm_match_arp_op( oxm_match, match->arp_opcode.value );
+	}
+	uint8_t eth_addr[ ETH_ADDRLEN ];
   uint8_t eth_addr_mask[ ETH_ADDRLEN ];
   if ( match->arp_sha[ 0 ].valid ) {
     byte_copy_match8( eth_addr, eth_addr_mask, &match->arp_sha[ 0 ], ETH_ADDRLEN );

--- a/unittests/lib/openflow_message_test.c
+++ b/unittests/lib/openflow_message_test.c
@@ -13023,7 +13023,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_tag_and_wildcards_is_zero
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_vlan_pcp( expected, packet_info0->vlan_prio );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13075,7 +13075,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_zero() {
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13127,7 +13127,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IN_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13180,7 +13180,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IN_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13233,7 +13233,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_META
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13285,7 +13285,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ETH_
     append_oxm_match_eth_src( expected, ether->macsa, mask.mask_eth_src );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13337,7 +13337,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ETH_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13433,7 +13433,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_VLAN
     append_oxm_match_eth_src( expected, ether->macsa, mask.mask_eth_src );
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13486,7 +13486,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_VLAN
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13539,7 +13539,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_D
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13592,7 +13592,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_E
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13645,7 +13645,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IP_P
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13698,7 +13698,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV4
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13751,7 +13751,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV4
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13804,7 +13804,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TCP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13857,7 +13857,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TCP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13910,7 +13910,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_UDP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -13963,7 +13963,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_UDP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14016,7 +14016,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_SCTP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14069,7 +14069,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_SCTP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14122,7 +14122,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14175,7 +14175,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14280,7 +14280,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14332,7 +14332,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14384,7 +14384,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_tha( expected, arp->tha, mask.mask_arp_tha );
@@ -14436,7 +14436,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ARP_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14488,7 +14488,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14541,7 +14541,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14594,7 +14594,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14647,7 +14647,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14700,7 +14700,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_ICMP
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14753,7 +14753,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14806,7 +14806,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14859,7 +14859,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14912,7 +14912,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -14965,7 +14965,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15018,7 +15018,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_MPLS
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15071,7 +15071,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_PBB_
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15124,7 +15124,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_TUNN
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );
@@ -15177,7 +15177,7 @@ test_set_match_from_packet_succeeds_if_datatype_is_arp_and_wildcards_is_OFB_IPV6
     append_oxm_match_eth_dst( expected, ether->macda, mask.mask_eth_dst );
     append_oxm_match_vlan_vid( expected, vlan_vid, mask.mask_vlan_vid );
     append_oxm_match_eth_type( expected, packet_info0->eth_type );
-    append_oxm_match_arp_opcode( expected, ntohs( arp->ar_op ) );
+    append_oxm_match_arp_op( expected, ntohs( arp->ar_op ) );
     append_oxm_match_arp_spa( expected, ntohl( arp->sip ), mask.mask_arp_spa );
     append_oxm_match_arp_tpa( expected, ntohl( arp->tip ), mask.mask_arp_tpa );
     append_oxm_match_arp_sha( expected, arp->sha, mask.mask_arp_sha );

--- a/unittests/lib/oxm_match_test.c
+++ b/unittests/lib/oxm_match_test.c
@@ -1282,16 +1282,16 @@ test_append_oxm_match_icmpv4_code() {
 
 
 static void
-test_append_oxm_match_arp_opcode() {
+test_append_oxm_match_arp_op() {
   const oxm_match_header type = OXM_OF_ARP_OP;
   const uint16_t data = data_16bit;
   const uint16_t offset = sizeof( oxm_match_header );
 
   oxm_matches *matches = create_oxm_matches();
 
-  expect_assert_failure( append_oxm_match_arp_opcode( NULL, data ) );
+  expect_assert_failure( append_oxm_match_arp_op( NULL, data ) );
 
-  bool ret = append_oxm_match_arp_opcode( matches, data );
+  bool ret = append_oxm_match_arp_op( matches, data );
   assert_true( ret );
 
   oxm_match_header *chk_hdr;
@@ -2122,7 +2122,7 @@ test_parse_ofp_match() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_opcode( expected, data_16bit );
+    append_oxm_match_arp_op( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -2215,7 +2215,7 @@ test_construct_ofp_match() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_opcode( expected, data_16bit );
+    append_oxm_match_arp_op( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -2311,7 +2311,7 @@ test_duplicate_oxm_matches() {
     append_oxm_match_sctp_dst( expected, data_16bit );
     append_oxm_match_icmpv4_type( expected, data_8bit );
     append_oxm_match_icmpv4_code( expected, data_8bit );
-    append_oxm_match_arp_opcode( expected, data_16bit );
+    append_oxm_match_arp_op( expected, data_16bit );
     append_oxm_match_arp_spa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( expected, data_32bit, mask_32bit );
     append_oxm_match_arp_sha( expected, d_48bit, m_48bit );
@@ -3095,9 +3095,9 @@ test_compare_oxm_match_with_arp_op() {
   y = create_oxm_matches();
   z = create_oxm_matches();
 
-  append_oxm_match_arp_opcode( x, 1 );
-  append_oxm_match_arp_opcode( y, 1 );
-  append_oxm_match_arp_opcode( z, 2 );
+  append_oxm_match_arp_op( x, 1 );
+  append_oxm_match_arp_op( y, 1 );
+  append_oxm_match_arp_op( z, 2 );
 
   assert_true( compare_oxm_match( x, y ) );
   assert_false( compare_oxm_match( x, z ) );
@@ -4655,9 +4655,9 @@ test_compare_oxm_match_strict_with_arp_op() {
   y = create_oxm_matches();
   z = create_oxm_matches();
 
-  append_oxm_match_arp_opcode( x, 1 );
-  append_oxm_match_arp_opcode( y, 1 );
-  append_oxm_match_arp_opcode( z, 2 );
+  append_oxm_match_arp_op( x, 1 );
+  append_oxm_match_arp_op( y, 1 );
+  append_oxm_match_arp_op( z, 2 );
 
   assert_true( compare_oxm_match_strict( x, y ) );
   assert_false( compare_oxm_match_strict( x, z ) );
@@ -5524,7 +5524,7 @@ main() {
     unit_test( test_append_oxm_match_sctp_dst ),
     unit_test( test_append_oxm_match_icmpv4_type ),
     unit_test( test_append_oxm_match_icmpv4_code ),
-    unit_test( test_append_oxm_match_arp_opcode ),
+    unit_test( test_append_oxm_match_arp_op ),
     unit_test( test_append_oxm_match_arp_spa ),
     unit_test( test_append_oxm_match_arp_tpa ),
     unit_test( test_append_oxm_match_arp_sha ),

--- a/unittests/lib/utility_test.c
+++ b/unittests/lib/utility_test.c
@@ -304,7 +304,7 @@ test_match_to_string() {
     append_oxm_match_sctp_dst( match, 6000 );
     append_oxm_match_icmpv4_type( match, 7 );
     append_oxm_match_icmpv4_code( match, 8 );
-    append_oxm_match_arp_opcode( match, data_16bit );
+    append_oxm_match_arp_op( match, data_16bit );
     append_oxm_match_arp_spa( match, data_32bit, nomask_32bit );
     append_oxm_match_arp_spa( match, data_32bit, mask_32bit );
     append_oxm_match_arp_tpa( match, data_32bit, nomask_32bit );


### PR DESCRIPTION
Please refer to #117

This is a better solution that keep using the append_oxm_match_arp_op() interface such that existing application don't need any modification.

However, we can not use APPEND_OXM_MATCH macro directly in oxm-helper.c
An exception is added to that file just like how we did to vlan_vid field (near line 480-488)
