### PR TITLE
call pcap_setnonblock() after pcap_activate()

### DIFF
--- a/src/switch/datapath/ether_device.c
+++ b/src/switch/datapath/ether_device.c
@@ -560,13 +560,13 @@ create_ether_device( const char *name, const size_t max_send_queue, const size_t
     warn( "Failed to set immediate mode for %s.", name );
   }
   #endif // USE_PCAP_IMMEDIATE_MODE
-  if ( pcap_setnonblock( handle, 1, errbuf ) == -1 ) {
-    warn( "Failed to setnonblock %s ( %s ).", name, errbuf );
-  }
   if ( pcap_activate( handle ) < 0 ) {
     error( "Failed to activate %s.", name );
     pcap_close( handle );
     return NULL;
+  }
+  if ( pcap_setnonblock( handle, 1, errbuf ) == -1 ) {
+    warn( "Failed to setnonblock %s ( %s ).", name, errbuf );
   }
 
   int fd = pcap_get_selectable_fd( handle );


### PR DESCRIPTION
libpcap looks expecting the function call order, that pcap_setnonblock() is called after pcap_activate().

This makes TPACKET_V3, TPACKET_V2(USE_PCAP_IMMEDIATE_MODE) both work fine.
